### PR TITLE
Changed the way Application instances are built

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -2,9 +2,11 @@
 
 // Application basic settings
 
+use Takemo101\Chubby\Application;
+
 return [
     // Application name
-    'name' => env('APP_NAME', 'Chubby'),
+    'name' => env('APP_NAME', Application::Name),
 
     // Application environment
     'env' => env('APP_ENV', 'local'),

--- a/console
+++ b/console
@@ -5,9 +5,11 @@ define('APP_START_TIME', microtime(true));
 
 require __DIR__ . '/vendor/autoload.php';
 
-$console = Takemo101\Chubby\Console::create(
-    Takemo101\Chubby\ApplicationOption::from(
-        basePath: getenv('APP_BASE_PATH') ?: __DIR__,
+$console = new Takemo101\Chubby\Console(
+    Takemo101\Chubby\ApplicationBuilder::buildStandard(
+        Takemo101\Chubby\ApplicationOption::from(
+            basePath: getenv('APP_BASE_PATH') ?: __DIR__,
+        ),
     ),
 );
 

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,6 @@
+{
+  "preset": "psr12",
+  "exclude": [
+    "tests"
+  ]
+}

--- a/public/index.php
+++ b/public/index.php
@@ -4,9 +4,11 @@ define('APP_START_TIME', microtime(true));
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$http = Takemo101\Chubby\Http::create(
-    Takemo101\Chubby\ApplicationOption::from(
-        basePath: getenv('APP_BASE_PATH') ?: dirname(__DIR__),
+$http = new Takemo101\Chubby\Http(
+    Takemo101\Chubby\ApplicationBuilder::buildStandard(
+        Takemo101\Chubby\ApplicationOption::from(
+            basePath: getenv('APP_BASE_PATH') ?: __DIR__,
+        ),
     ),
 );
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -30,7 +30,6 @@ use Takemo101\Chubby\Bootstrap\Provider\LogProvider;
 use Takemo101\Chubby\Filesystem\LocalFilesystem;
 use Takemo101\Chubby\Filesystem\LocalSystem;
 use Takemo101\Chubby\Filesystem\PathHelper;
-use Takemo101\Chubby\Support\Environment;
 
 use function DI\get;
 
@@ -104,16 +103,13 @@ final class Application implements ApplicationContainer
                 InvokerInterface::class => get(Application::class),
                 FactoryInterface::class => get(Application::class),
                 ApplicationSummary::class => function (
-                    Environment $environment,
+                    ConfigRepository $config,
                 ): ApplicationSummary {
-                    /** @var ConfigRepository */
-                    $config = $this->make(ConfigRepository::class);
-
                     /** @var string */
-                    $env = $config->get('app.env', $environment->get('APP_ENV', 'local'));
+                    $env = $config->get('app.env', 'local');
 
                     /** @var boolean */
-                    $debug = (bool) $config->get('app.debug', $environment->get('APP_DEBUG', true));
+                    $debug = (bool) $config->get('app.debug', true);
 
                     return new ApplicationSummary(
                         env: $env,

--- a/src/ApplicationBuilder.php
+++ b/src/ApplicationBuilder.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Takemo101\Chubby;
+
+use Takemo101\Chubby\Bootstrap\Provider\ConsoleProvider;
+use Takemo101\Chubby\Bootstrap\Provider\DependencyProvider;
+use Takemo101\Chubby\Bootstrap\Provider\FunctionProvider;
+use Takemo101\Chubby\Bootstrap\Provider\HttpProvider;
+use Takemo101\Chubby\Filesystem\LocalFilesystem;
+
+/**
+ * Support classes for building applications.
+ */
+class ApplicationBuilder
+{
+    /**
+     * constructor
+     *
+     * @param Application $app
+     * @throws ApplicationAlreadyBootedException
+     */
+    final public function __construct(
+        private Application $app,
+    ) {
+        if ($app->isBooted()) {
+            throw new ApplicationAlreadyBootedException();
+        }
+    }
+
+    /**
+     * Add the ability to set dependencies loaded from setting/dependency.php in the DI container.
+     *
+     * @return static
+     */
+    public function addDependencySetting(): static
+    {
+        $this->getApplication()->addProvider(
+            new DependencyProvider(
+                $this->getApplication()->getPath(),
+                new LocalFilesystem(),
+            ),
+        );
+
+        return $this;
+    }
+
+    /**
+     * Load setting/function.php so that you can initialize the application.
+     *
+     * @return static
+     */
+    public function addFunctionSetting(): static
+    {
+        $this->getApplication()->addProvider(
+            new FunctionProvider(),
+        );
+
+        return $this;
+    }
+
+    /**
+     * Add cli functionality using symfony/console.
+     *
+     * @return static
+     */
+    public function addConsole(): static
+    {
+        $this->getApplication()->addProvider(
+            new ConsoleProvider(),
+        );
+
+        return $this;
+    }
+
+    /**
+     * Add http routing function by slim.
+     *
+     * @return static
+     */
+    public function addHttp(): static
+    {
+        $this
+            ->getApplication()
+            ->addProvider(
+                new HttpProvider(),
+            );
+
+        return $this;
+    }
+
+    /**
+     * Obtain an Application instance with various functions given by ApplicationBuilder.
+     *
+     * @return Application
+     */
+    public function getApplication(): Application
+    {
+        return $this->app;
+    }
+
+    /**
+     * Create ApplicationBuilder from any option.
+     *
+     * @param ApplicationOption|null $option
+     * @return static
+     */
+    public static function fromOption(
+        ?ApplicationOption $option = null,
+    ): static {
+        return new static(
+            Application::fromOption(
+                $option ?? ApplicationOption::from(),
+            ),
+        );
+    }
+
+    /**
+     * Create ApplicationBuilder from any option and get Application as is.
+     *
+     * @param ApplicationOption|null $option
+     * @return Application
+     */
+    public static function build(
+        ?ApplicationOption $option = null,
+    ): Application {
+        return static::fromOption($option)
+            ->getApplication();
+    }
+
+    /**
+     * Create ApplicationBuilder from any option and get Application with standard settings.
+     * It is recommended to create an instance of Application from this method in order to take advantage of all features.
+     *
+     * @param ApplicationOption|null $option
+     * @return Application
+     */
+    public static function buildStandard(
+        ?ApplicationOption $option = null,
+    ): Application {
+        return static::fromOption($option)
+            ->addDependencySetting()
+            ->addFunctionSetting()
+            ->addConsole()
+            ->addHttp()
+            ->getApplication();
+    }
+}

--- a/src/Bootstrap/Bootstrap.php
+++ b/src/Bootstrap/Bootstrap.php
@@ -13,7 +13,7 @@ use Takemo101\Chubby\Bootstrap\Provider\ProviderNameable;
 final class Bootstrap implements Provider
 {
     /**
-     * @var Provider[]
+     * @var array<string,Provider>
      */
     private array $providers;
 
@@ -51,9 +51,9 @@ final class Bootstrap implements Provider
     /**
      * Get providers
      *
-     * @return Provider[]
+     * @return array<string,Provider>
      */
-    public function providers(): array
+    public function getProviders(): array
     {
         return $this->providers;
     }

--- a/src/Bootstrap/Provider/ConfigProvider.php
+++ b/src/Bootstrap/Provider/ConfigProvider.php
@@ -8,6 +8,7 @@ use Takemo101\Chubby\Bootstrap\Definitions;
 use Takemo101\Chubby\Config\ConfigPhpRepository;
 use Takemo101\Chubby\Config\ConfigRepository;
 use Takemo101\Chubby\Filesystem\LocalSystem;
+use Takemo101\Chubby\Hook\Hook;
 use Takemo101\Chubby\Support\ApplicationPath;
 
 /**
@@ -38,11 +39,14 @@ class ConfigProvider implements Provider
                 ConfigRepository::class => function (
                     LocalSystem $filesystem,
                     ApplicationPath $path,
+                    Hook $hook,
                 ): ConfigRepository {
                     $config = new ConfigPhpRepository(
                         filesystem: $filesystem,
                         directory: $path->getConfigPath(),
                     );
+
+                    $hook->do(ConfigRepository::class, $config);
 
                     return $config;
                 },

--- a/src/Bootstrap/Provider/ConfigProvider.php
+++ b/src/Bootstrap/Provider/ConfigProvider.php
@@ -76,6 +76,12 @@ class ConfigProvider implements Provider
         $this->setDefaultTimezone($config);
     }
 
+    /**
+     * Set default timezone.
+     *
+     * @param ConfigRepository $config
+     * @return void
+     */
     private function setDefaultTimezone(ConfigRepository $config): void
     {
         /** @var string */

--- a/src/Bootstrap/Provider/ConfigProvider.php
+++ b/src/Bootstrap/Provider/ConfigProvider.php
@@ -9,7 +9,6 @@ use Takemo101\Chubby\Config\ConfigPhpRepository;
 use Takemo101\Chubby\Config\ConfigRepository;
 use Takemo101\Chubby\Filesystem\LocalSystem;
 use Takemo101\Chubby\Support\ApplicationPath;
-use Illuminate\Support\Arr;
 
 /**
  * Config data related.

--- a/src/Bootstrap/Provider/DependencyProvider.php
+++ b/src/Bootstrap/Provider/DependencyProvider.php
@@ -39,7 +39,7 @@ class DependencyProvider implements Provider
      */
     public function register(Definitions $definitions): void
     {
-        $dependencyPath = $this->getDependencyPath();
+        $dependencyPath = $this->getDependencyPath($this->path);
 
         /** @var mixed[] */
         $dependency = $this->filesystem->exists($dependencyPath)
@@ -71,10 +71,12 @@ class DependencyProvider implements Provider
     /**
      * Get dependency definitions path.
      *
+     * @param ApplicationPath $path
      * @return string
      */
-    protected function getDependencyPath(): string
-    {
-        return $this->path->getSettingPath('dependency.php');
+    protected function getDependencyPath(
+        ApplicationPath $path,
+    ): string {
+        return $path->getSettingPath('dependency.php');
     }
 }

--- a/src/Bootstrap/Provider/EnvironmentProvider.php
+++ b/src/Bootstrap/Provider/EnvironmentProvider.php
@@ -34,7 +34,7 @@ class EnvironmentProvider implements Provider
      * @param ApplicationPath $path
      */
     public function __construct(
-        protected ApplicationPath $path,
+        private ApplicationPath $path,
     ) {
         //
     }
@@ -57,7 +57,7 @@ class EnvironmentProvider implements Provider
                         ->immutable()
                         ->make();
 
-                    $paths = $this->getDotenvPaths();
+                    $paths = $this->getDotenvPaths($this->path);
                     $names = $this->path->getDotenvNames();
 
                     try {
@@ -99,10 +99,11 @@ class EnvironmentProvider implements Provider
     /**
      * Get dotenv path.
      *
+     * @param ApplicationPath $path
      * @return string|string[];
      */
-    protected function getDotenvPaths(): string|array
+    protected function getDotenvPaths(ApplicationPath $path): string|array
     {
-        return $this->path->getBasePath();
+        return $path->getBasePath();
     }
 }

--- a/src/Bootstrap/Provider/FunctionProvider.php
+++ b/src/Bootstrap/Provider/FunctionProvider.php
@@ -18,19 +18,6 @@ class FunctionProvider implements Provider
     public const ProviderName = 'function';
 
     /**
-     * constructor
-     *
-     * @param ApplicationPath $path
-     * @param LocalSystem $filesystem
-     */
-    public function __construct(
-        protected ApplicationPath $path,
-        protected LocalSystem $filesystem,
-    ) {
-        //
-    }
-
-    /**
      * Execute Bootstrap providing process.
      *
      * @param Definitions $definitions
@@ -49,9 +36,15 @@ class FunctionProvider implements Provider
      */
     public function boot(ApplicationContainer $container): void
     {
-        $functionPath = $this->getFunctionPath();
+        /** @var ApplicationPath */
+        $path = $container->get(ApplicationPath::class);
 
-        if ($this->filesystem->exists($functionPath)) {
+        /** @var LocalSystem */
+        $filesystem = $container->get(LocalSystem::class);
+
+        $functionPath = $this->getFunctionPath($path);
+
+        if ($filesystem->exists($functionPath)) {
             require $functionPath;
         }
     }
@@ -59,10 +52,11 @@ class FunctionProvider implements Provider
     /**
      * Get function path.
      *
+     * @param ApplicationPath $path
      * @return string
      */
-    protected function getFunctionPath(): string
+    protected function getFunctionPath(ApplicationPath $path): string
     {
-        return $this->path->getSettingPath('function.php');
+        return $path->getSettingPath('function.php');
     }
 }

--- a/src/Bootstrap/Provider/HttpProvider.php
+++ b/src/Bootstrap/Provider/HttpProvider.php
@@ -21,6 +21,7 @@ use Takemo101\Chubby\Hook\Hook;
 use Takemo101\Chubby\Http\Bridge\ControllerInvoker;
 use Takemo101\Chubby\Http\ErrorHandler\ErrorHandler;
 use Takemo101\Chubby\Http\ResponseTransformer\ArrayableTransformer;
+use Takemo101\Chubby\Http\ResponseTransformer\RenderableTransformer;
 use Takemo101\Chubby\Http\ResponseTransformer\RendererTransformer;
 use Takemo101\Chubby\Http\ResponseTransformer\ResponseTransformers;
 use Takemo101\Chubby\Http\ResponseTransformer\StringableTransformer;
@@ -95,6 +96,7 @@ class HttpProvider implements Provider
                     $transformers = new ResponseTransformers(
                         new RendererTransformer(),
                         new ArrayableTransformer(),
+                        new RenderableTransformer(),
                         new StringableTransformer(),
                     );
 

--- a/src/Bootstrap/Provider/LogProvider.php
+++ b/src/Bootstrap/Provider/LogProvider.php
@@ -37,7 +37,7 @@ class LogProvider implements Provider
                 ): LoggerFactory {
 
                     /** @var string */
-                    $path = $config->get('log.path', 'log');
+                    $path = $config->get('log.path', $path->getStoragePath('logs'));
 
                     /** @var string */
                     $filename = $config->get('log.filename', 'error.log');

--- a/src/Config/ConfigPhpRepository.php
+++ b/src/Config/ConfigPhpRepository.php
@@ -158,6 +158,7 @@ class ConfigPhpRepository implements ConfigRepository
     public function set(string $key, $value): void
     {
         $firstKey = $this->firstDotKey($key);
+
         $this->loadData($firstKey);
 
         Arr::set($this->config, $key, $value);
@@ -175,6 +176,27 @@ class ConfigPhpRepository implements ConfigRepository
         $this->loadData($firstKey);
 
         return Arr::has($this->config, $key);
+    }
+
+    /**
+     * Get all data.
+     *
+     * @return array<string,mixed>
+     */
+    public function all(): array
+    {
+        foreach ($this->config as $key => $value) {
+            /** @var string|mixed[] */
+            $pathOrConfig = $value;
+
+            if (is_string($pathOrConfig)) {
+                $result = $this->resolve($pathOrConfig);
+
+                $this->config[$key] = $result;
+            }
+        }
+
+        return $this->config;
     }
 
     /**

--- a/src/Config/ConfigRepository.php
+++ b/src/Config/ConfigRepository.php
@@ -52,4 +52,11 @@ interface ConfigRepository extends ArrayAccess
      * @return boolean
      */
     public function has(string $key): bool;
+
+    /**
+     * Get all data.
+     *
+     * @return array<string,mixed>
+     */
+    public function all(): array;
 }

--- a/src/Console.php
+++ b/src/Console.php
@@ -78,4 +78,20 @@ final readonly class Console extends AbstractRunner
             output: $output,
         );
     }
+
+    /**
+     * Create a simple instance with only Console functionality available from options
+     *
+     * @param ApplicationOption|null $option
+     * @return self
+     */
+    public static function createSimple(
+        ?ApplicationOption $option = null,
+    ): self {
+        return new self(
+            ApplicationBuilder::fromOption($option)
+                ->addConsole()
+                ->getApplication(),
+        );
+    }
 }

--- a/src/Console/Command/ServeCommand.php
+++ b/src/Console/Command/ServeCommand.php
@@ -84,6 +84,7 @@ final class ServeCommand extends Command
             $port,
             $this->getScriptPath(
                 $path->getBasePath($script),
+                $this->getDefaultScriptPaths($path),
             ),
             $path->getBasePath(),
             $environments,
@@ -148,22 +149,40 @@ final class ServeCommand extends Command
      * If the specified script file does not exist, return the default script file path.
      *
      * @param string $script
+     * @param string[] $defaultPaths
      * @return string
      */
-    private function getScriptPath(string $script): string
-    {
-        return file_exists($script)
-            ? $script
-            : $this->getDefaultScriptPath();
+    private function getScriptPath(
+        string $script,
+        array $defaultPaths,
+    ): string {
+        /** @var string[] */
+        $paths = array_unique([
+            $script,
+            ...$defaultPaths,
+        ]);
+
+        foreach ($paths as $path) {
+            if (file_exists($path)) {
+                return $path;
+            }
+        }
+
+        throw new RuntimeException('Unable to find the script file.');
     }
 
     /**
      * Get default script path.
      *
-     * @return string
+     * @param ApplicationPath $path
+     * @return string[]
      */
-    private function getDefaultScriptPath(): string
+    private function getDefaultScriptPaths(ApplicationPath $path): array
     {
-        return __DIR__ . '/../../../public/index.php';
+        return [
+            $path->getBasePath('/public/index.php'),
+            $path->getBasePath('/index.php'),
+            $path->getSettingPath('/index.php'),
+        ];
     }
 }

--- a/src/Contract/Arrayable.php
+++ b/src/Contract/Arrayable.php
@@ -4,13 +4,16 @@ namespace Takemo101\Chubby\Contract;
 
 /**
  * Arrayable interface.
+ *
+ * @template TKey of array-key
+ * @template TValue
  */
 interface Arrayable
 {
     /**
      * Convert the object to its array representation.
      *
-     * @return mixed[]
+     * @return array<TKey,TValue>
      */
     public function toArray(): array;
 }

--- a/src/Contract/Renderable.php
+++ b/src/Contract/Renderable.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Takemo101\Chubby\Contract;
+
+/**
+ * Renderable interface.
+ */
+interface Renderable
+{
+    /**
+     * Convert the object to its string representation.
+     *
+     * @return string
+     */
+    public function render(): string;
+}

--- a/src/Http.php
+++ b/src/Http.php
@@ -95,4 +95,20 @@ final readonly class Http extends AbstractRunner
 
         throw new BadMethodCallException("method not found: {$name}");
     }
+
+    /**
+     * Create a simple instance with only Http functionality available from options
+     *
+     * @param ApplicationOption|null $option
+     * @return self
+     */
+    public static function createSimple(
+        ?ApplicationOption $option = null,
+    ): self {
+        return new self(
+            ApplicationBuilder::fromOption($option)
+                ->addHttp()
+                ->getApplication(),
+        );
+    }
 }

--- a/src/Http/Renderer/HtmlRenderer.php
+++ b/src/Http/Renderer/HtmlRenderer.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Takemo101\Chubby\Http\Renderer;
+
+class HtmlRenderer extends StringRenderer
+{
+    /** @var string */
+    public const ContentType = 'text/html';
+}

--- a/src/Http/Renderer/StringRenderer.php
+++ b/src/Http/Renderer/StringRenderer.php
@@ -5,9 +5,13 @@ namespace Takemo101\Chubby\Http\Renderer;
 use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Takemo101\Chubby\Contract\Renderable;
 
-final class StringRenderer implements ResponseRenderer
+class StringRenderer implements ResponseRenderer
 {
+    /** @var string */
+    public const ContentType = 'text/plain';
+
     /**
      * constructor
      *
@@ -36,14 +40,20 @@ final class StringRenderer implements ResponseRenderer
     ): ResponseInterface {
         $response = $response
             ->withStatus($this->status)
-            ->withHeader('Content-Type', 'text/plain');
+            ->withHeader('Content-Type', static::ContentType);
 
         foreach ($this->headers as $key => $value) {
             $response = $response->withHeader($key, $value);
         }
 
+        $data = $this->data;
+
+        if ($data instanceof Renderable) {
+            $data = $data->render();
+        }
+
         $response->getBody()->write(
-            (string) $this->data, // @phpstan-ignore-line
+            (string) $data, // @phpstan-ignore-line
         );
 
         return $response;

--- a/src/Http/ResponseTransformer/RenderableTransformer.php
+++ b/src/Http/ResponseTransformer/RenderableTransformer.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Takemo101\Chubby\Http\ResponseTransformer;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Takemo101\Chubby\Contract\Renderable;
+use Takemo101\Chubby\Http\Renderer\HtmlRenderer;
+
+final class RenderableTransformer implements ResponseTransformer
+{
+    /**
+     * Change the data type and convert it into a response object.
+     * If not converted to a response, return null.
+     *
+     * @param mixed $data
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     * @return ResponseInterface|null
+     */
+    public function transform(
+        mixed $data,
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+    ): ?ResponseInterface {
+        return $data instanceof Renderable
+            ? (new HtmlRenderer($data))->render($request, $response)
+            : null;
+    }
+}

--- a/src/Http/ResponseTransformer/ResponseTransformers.php
+++ b/src/Http/ResponseTransformer/ResponseTransformers.php
@@ -53,14 +53,16 @@ final class ResponseTransformers implements ResponseTransformer
         ServerRequestInterface $request,
         ResponseInterface $response,
     ): ?ResponseInterface {
+        if ($data instanceof ResponseInterface) {
+            return $data;
+        }
+
         foreach ($this->transformers as $transformer) {
             if ($output = $transformer->transform($data, $request, $response)) {
                 return $output;
             }
         }
 
-        return $data instanceof ResponseInterface
-            ? $data
-            : null;
+        return null;
     }
 }

--- a/src/Support/AbstractRunner.php
+++ b/src/Support/AbstractRunner.php
@@ -3,10 +3,7 @@
 namespace Takemo101\Chubby\Support;
 
 use Takemo101\Chubby\Application;
-use Takemo101\Chubby\ApplicationOption;
-use Takemo101\Chubby\Bootstrap\Provider\ConsoleProvider;
 use Takemo101\Chubby\Bootstrap\Provider\Provider;
-use Takemo101\Chubby\Bootstrap\Provider\HttpProvider;
 
 /**
  * Abstract class for running applications.
@@ -44,39 +41,5 @@ abstract readonly class AbstractRunner
     protected function getApp(): Application
     {
         return $this->app;
-    }
-
-    /**
-     * Create an application instance with standard functionality from any option.
-     *
-     * @param ApplicationOption|null $option
-     * @return static
-     */
-    public static function create(
-        ?ApplicationOption $option = null
-    ): static {
-        return new static(Application::create(
-            $option ?? ApplicationOption::from(),
-        )->addProvider(
-            new HttpProvider(),
-            new ConsoleProvider(),
-        ));
-    }
-
-    /**
-     * Create an application instance with simple functionality from any option.
-     *
-     * @param ApplicationOption|null $option
-     * @return static
-     */
-    public static function createSimple(
-        ?ApplicationOption $option = null
-    ): static {
-        return new static(Application::createSimple(
-            $option ?? ApplicationOption::from(),
-        )->addProvider(
-            new HttpProvider(),
-            new ConsoleProvider(),
-        ));
     }
 }

--- a/tests/AppTestCase.php
+++ b/tests/AppTestCase.php
@@ -3,10 +3,8 @@
 namespace Tests;
 
 use PHPUnit\Framework\TestCase as BaseTestCase;
-use Takemo101\Chubby\Application;
+use Takemo101\Chubby\ApplicationBuilder;
 use Takemo101\Chubby\ApplicationOption;
-use Takemo101\Chubby\Bootstrap\Provider\ConsoleProvider;
-use Takemo101\Chubby\Bootstrap\Provider\HttpProvider;
 use Takemo101\Chubby\Test\HasConsoleTest;
 use Takemo101\Chubby\Test\HasContainerTest;
 use Takemo101\Chubby\Test\HasHttpTest;
@@ -23,14 +21,14 @@ class AppTestCase extends BaseTestCase
     protected function setUp(): void
     {
         $this->setUpContainer(
-            Application::createSimple(
+            ApplicationBuilder::fromOption(
                 ApplicationOption::from(
                     basePath: __DIR__ . '/../',
                 ),
-            )->addProvider(
-                new HttpProvider(),
-                new ConsoleProvider(),
-            ),
+            )
+                ->addHttp()
+                ->addConsole()
+                ->getApplication(),
         );
         $this->setUpHttp();
         $this->setUpConsole();

--- a/tests/Application/ApplicationBuilderTest.php
+++ b/tests/Application/ApplicationBuilderTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use Takemo101\Chubby\ApplicationBuilder;
+use Takemo101\Chubby\ApplicationOption;
+use Takemo101\Chubby\Bootstrap\Bootstrap;
+use Takemo101\Chubby\Bootstrap\Provider\ConsoleProvider;
+use Takemo101\Chubby\Bootstrap\Provider\DependencyProvider;
+use Takemo101\Chubby\Bootstrap\Provider\FunctionProvider;
+use Takemo101\Chubby\Bootstrap\Provider\HttpProvider;
+
+describe(
+    'application builder',
+    function () {
+        test(
+            'Add Provider to Application by ApplicationBuilder',
+            function (string $builderMethod, string $providerClass) {
+                $bootstrap = new Bootstrap();
+
+                $builder = ApplicationBuilder::fromOption(
+                    ApplicationOption::from(
+                        bootstrap: $bootstrap,
+                    ),
+                );
+
+                $builder->{$builderMethod}();
+
+                $actualProviderClassNames = array_map(
+                    fn ($provider) => get_class($provider),
+                    $bootstrap->getProviders(),
+                );
+
+                expect($actualProviderClassNames)->toContain($providerClass);
+            },
+        )->with([
+            [
+                'addHttp', HttpProvider::class,
+            ],
+            [
+                'addConsole', ConsoleProvider::class,
+            ],
+            [
+                'addFunctionSetting', FunctionProvider::class,
+            ],
+            [
+                'addDependencySetting', DependencyProvider::class,
+            ]
+        ]);
+
+        test(
+            'Add the required providers using the buildStandard method',
+            function () {
+                $bootstrap = new Bootstrap();
+
+                ApplicationBuilder::buildStandard(
+                    ApplicationOption::from(
+                        bootstrap: $bootstrap,
+                    ),
+                );
+
+                $actualProviderClassNames = array_map(
+                    fn ($provider) => get_class($provider),
+                    $bootstrap->getProviders(),
+                );
+
+                foreach ([
+                    HttpProvider::class,
+                    ConsoleProvider::class,
+                    FunctionProvider::class,
+                    DependencyProvider::class,
+                ] as $excepted) {
+                    expect($actualProviderClassNames)->toContain($excepted);
+                }
+            }
+        );
+    }
+)->group('application-builder');

--- a/tests/Application/ApplicationBuilderTest.php
+++ b/tests/Application/ApplicationBuilderTest.php
@@ -7,6 +7,8 @@ use Takemo101\Chubby\Bootstrap\Provider\ConsoleProvider;
 use Takemo101\Chubby\Bootstrap\Provider\DependencyProvider;
 use Takemo101\Chubby\Bootstrap\Provider\FunctionProvider;
 use Takemo101\Chubby\Bootstrap\Provider\HttpProvider;
+use Takemo101\Chubby\Console;
+use Takemo101\Chubby\Http;
 
 describe(
     'application builder',
@@ -70,6 +72,46 @@ describe(
                 ] as $excepted) {
                     expect($actualProviderClassNames)->toContain($excepted);
                 }
+            }
+        );
+
+        test(
+            "Http's createSimple method adds HttpProvider to Application via ApplicationBuilder",
+            function () {
+                $bootstrap = new Bootstrap();
+
+                Http::createSimple(
+                    ApplicationOption::from(
+                        bootstrap: $bootstrap,
+                    ),
+                );
+
+                $actualProviderClassNames = array_map(
+                    fn ($provider) => get_class($provider),
+                    $bootstrap->getProviders(),
+                );
+
+                expect($actualProviderClassNames)->toContain(HttpProvider::class);
+            }
+        );
+
+        test(
+            "Console's createSimple method adds HttpProvider to Application via ApplicationBuilder",
+            function () {
+                $bootstrap = new Bootstrap();
+
+                Console::createSimple(
+                    ApplicationOption::from(
+                        bootstrap: $bootstrap,
+                    ),
+                );
+
+                $actualProviderClassNames = array_map(
+                    fn ($provider) => get_class($provider),
+                    $bootstrap->getProviders(),
+                );
+
+                expect($actualProviderClassNames)->toContain(ConsoleProvider::class);
             }
         );
     }

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -57,11 +57,12 @@ describe(
                     ),
                 );
 
-                $initialProviderCount = count($bootstrap->providers());
+                $initialProviderCount = count($bootstrap->getProviders());
 
                 expect($initialProviderCount)->toBeGreaterThan(0);
 
-                $provider = new class () implements Provider {
+                $provider = new class() implements Provider
+                {
                     public const ProviderName = 'test';
 
                     public function register(Definitions $definitions): void
@@ -82,14 +83,15 @@ describe(
                     $provider,
                 );
 
-                expect(count($bootstrap->providers()))->toEqual($initialProviderCount + 1);
+                expect(count($bootstrap->getProviders()))->toEqual($initialProviderCount + 1);
             },
         );
 
         test(
             "Run Bootstrap's Provider via Application",
             function () {
-                $provider = new class () implements Provider {
+                $provider = new class() implements Provider
+                {
                     public const ProviderName = 'test';
 
                     public bool $booted = false;
@@ -159,7 +161,8 @@ describe(
                 $app->boot();
 
                 expect(fn () => $app->addProvider(
-                    new class () implements Provider {
+                    new class() implements Provider
+                    {
                         public function register(Definitions $definitions): void
                         {
                             //

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -51,7 +51,7 @@ describe(
             function () {
                 $bootstrap = new Bootstrap();
 
-                $app = Application::create(
+                $app = Application::fromOption(
                     ApplicationOption::from(
                         bootstrap: $bootstrap,
                     ),
@@ -107,7 +107,7 @@ describe(
                     }
                 };
 
-                $app = Application::create(
+                $app = Application::fromOption(
                     ApplicationOption::from(
                         bootstrap: new Bootstrap($provider),
                     ),

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -61,8 +61,7 @@ describe(
 
                 expect($initialProviderCount)->toBeGreaterThan(0);
 
-                $provider = new class() implements Provider
-                {
+                $provider = new class () implements Provider {
                     public const ProviderName = 'test';
 
                     public function register(Definitions $definitions): void
@@ -90,8 +89,7 @@ describe(
         test(
             "Run Bootstrap's Provider via Application",
             function () {
-                $provider = new class() implements Provider
-                {
+                $provider = new class () implements Provider {
                     public const ProviderName = 'test';
 
                     public bool $booted = false;
@@ -161,8 +159,7 @@ describe(
                 $app->boot();
 
                 expect(fn () => $app->addProvider(
-                    new class() implements Provider
-                    {
+                    new class () implements Provider {
                         public function register(Definitions $definitions): void
                         {
                             //

--- a/tests/ApplicationTestCase.php
+++ b/tests/ApplicationTestCase.php
@@ -5,6 +5,7 @@ namespace Tests;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use Takemo101\Chubby\Application;
 use Takemo101\Chubby\ApplicationOption;
+use Takemo101\Chubby\ApplicationBuilder;
 
 class ApplicationTestCase extends BaseTestCase
 {
@@ -15,7 +16,7 @@ class ApplicationTestCase extends BaseTestCase
      */
     public function createApplication(): Application
     {
-        return Application::createSimple(
+        return ApplicationBuilder::build(
             ApplicationOption::from(
                 basePath: __DIR__ . '/../',
             ),

--- a/tests/Config/ConfigRepositoryTest.php
+++ b/tests/Config/ConfigRepositoryTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Takemo101\Chubby\Config\ConfigPhpRepository;
 use Tests\Config\ConfigTestCase;
 
 describe(
@@ -92,5 +93,32 @@ describe(
                 ['another-config.bar', 'baz'],
             ]
         );
+
+        test(
+            '',
+            function (array $excepted) {
+                $repository = new ConfigPhpRepository();
+
+                foreach ($excepted as $key => $value) {
+                    $repository->set($key, $value);
+                }
+
+                expect($repository->all())->toEqual($excepted);
+            },
+        )->with([
+            fn () => [
+                'hoge' => [
+                    'fuga' => 'piyo',
+                ],
+                'foo' => ['bar'],
+            ],
+            fn () => [
+                'test' => [
+                    'test' => 'test',
+                ],
+                'test01' => ['test'],
+                'test02' => ['test'],
+            ],
+        ]);
     }
 )->group('config');


### PR DESCRIPTION
Mainly, the method of building Application instances was changed.

Package users need to create different variations of Application instances for different use cases.
However, since the Application itself included many functions for creating instances, it was difficult to use it.
For this reason, we separated the instance construction function from the Application class and created an ApplicationBuilder class that only performs instance construction.

The changes are as follows:
1. Created an ApplicationBuilder class to be able to construct Application instances.
2. ConfigProvider now allows dependency injection of config contents directly from the DI container.
3. Added Html response processing.
4. Added Renderable interface to allow drawing responses from objects.

