### PR TITLE
Add functionality to ConfigRepository

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -43,7 +43,7 @@ final class Application implements ApplicationContainer
     /**
      * @var string
      */
-    public const Version = '0.0.8';
+    public const Version = '0.0.9';
 
     /**
      * @var Container|null

--- a/src/Bootstrap/Provider/ConfigProvider.php
+++ b/src/Bootstrap/Provider/ConfigProvider.php
@@ -36,20 +36,13 @@ class ConfigProvider implements Provider
     {
         $definitions->add(
             [
-                ConfigRepository::class => function (
+                ConfigRepository::class => fn (
                     LocalFilesystem $filesystem,
                     ApplicationPath $path,
-                    Hook $hook,
-                ): ConfigRepository {
-                    $config = new ConfigPhpRepository(
-                        filesystem: $filesystem,
-                        directory: $path->getConfigPath(),
-                    );
-
-                    $hook->do(ConfigRepository::class, $config);
-
-                    return $config;
-                },
+                ) => new ConfigPhpRepository(
+                    filesystem: $filesystem,
+                    directory: $path->getConfigPath(),
+                ),
                 // Inject the value like #[Inject('config.app.name')]
                 self::ConfigPrependKey . '.*' => function (
                     ConfigRepository $config,

--- a/src/Bootstrap/Provider/ConfigProvider.php
+++ b/src/Bootstrap/Provider/ConfigProvider.php
@@ -8,7 +8,6 @@ use Takemo101\Chubby\Bootstrap\Definitions;
 use Takemo101\Chubby\Config\ConfigPhpRepository;
 use Takemo101\Chubby\Config\ConfigRepository;
 use Takemo101\Chubby\Filesystem\LocalFilesystem;
-use Takemo101\Chubby\Hook\Hook;
 use Takemo101\Chubby\Support\ApplicationPath;
 
 /**

--- a/src/Config/ConfigPhpRepository.php
+++ b/src/Config/ConfigPhpRepository.php
@@ -128,14 +128,7 @@ class ConfigPhpRepository implements ConfigRepository
             return $config;
         }
 
-        $result = require $config;
-
-        //　If it is not an array, it is not config data and an error occurs.
-        if (!is_array($result)) {
-            throw new RuntimeException("config data is not array. path: {$config}");
-        }
-
-        return $result;
+        return self::getConfigByPath($config);
     }
 
     /**
@@ -167,6 +160,27 @@ class ConfigPhpRepository implements ConfigRepository
         $this->loadData($firstKey);
 
         Arr::set($this->config, $key, $value);
+    }
+
+    /**
+     * Merge data for the specified key (specify the key using dot notation)
+     *
+     * @param string $key
+     * @param mixed[] $value
+     * @return void
+     */
+    public function merge(string $key, array $value): void
+    {
+        $firstKey = $this->firstDotKey($key);
+
+        $this->loadData($firstKey);
+
+        $current = Arr::get($this->config, $key, []);
+
+        $this->set($key, [
+            ...$current,
+            ...$value,
+        ]);
     }
 
     /**
@@ -247,5 +261,24 @@ class ConfigPhpRepository implements ConfigRepository
     public function offsetUnset($offset): void
     {
         // not processing
+    }
+
+    /**
+     * Get config data array from the specified path
+     *
+     * @param string $path
+     * @return mixed[]
+     * @throws RuntimeException
+     */
+    public static function getConfigByPath(string $path): array
+    {
+        $result = require $path;
+
+        // If it is not an array, it is not config data and an error occurs.
+        if (!is_array($result)) {
+            throw new RuntimeException("config data is not array. path: {$path}");
+        }
+
+        return $result;
     }
 }

--- a/src/Config/ConfigPhpRepository.php
+++ b/src/Config/ConfigPhpRepository.php
@@ -177,10 +177,16 @@ class ConfigPhpRepository implements ConfigRepository
 
         $current = Arr::get($this->config, $key, []);
 
-        $this->set($key, [
-            ...$current,
-            ...$value,
-        ]);
+        Arr::set(
+            $this->config,
+            $key,
+            is_array($current)
+                ? [
+                    ...$current,
+                    ...$value,
+                ]
+                : $value
+        );
     }
 
     /**

--- a/src/Config/ConfigPhpRepository.php
+++ b/src/Config/ConfigPhpRepository.php
@@ -71,9 +71,10 @@ class ConfigPhpRepository implements ConfigRepository
      * Load configuration data from specified directory path.
      *
      * @param string $directory
+     * @param boolean $overwrite Overwrite settings with the same file name (key name)?
      * @return void
      */
-    public function load(string $directory): void
+    public function load(string $directory, bool $overwrite = false): void
     {
         $ext = self::ConfigExtension;
 
@@ -87,6 +88,10 @@ class ConfigPhpRepository implements ConfigRepository
 
         foreach ($paths as $path) {
             $key = $this->extractKeyByPath($path);
+
+            if (!$overwrite && array_key_exists($key, $this->config)) {
+                continue;
+            }
 
             $this->config[$key] = $path;
         }

--- a/src/Config/ConfigRepository.php
+++ b/src/Config/ConfigRepository.php
@@ -23,9 +23,10 @@ interface ConfigRepository extends ArrayAccess
      * Load configuration data from specified directory path.
      *
      * @param string $directory
+     * @param boolean $overwrite Overwrite settings with the same file name (key name)?
      * @return void
      */
-    public function load(string $directory): void;
+    public function load(string $directory, bool $overwrite = false): void;
 
     /**
      * Get data for the specified key (specify the key using dot notation)

--- a/src/Config/ConfigRepository.php
+++ b/src/Config/ConfigRepository.php
@@ -47,6 +47,15 @@ interface ConfigRepository extends ArrayAccess
     public function set(string $key, $value): void;
 
     /**
+     * Merge data for the specified key (specify the key using dot notation)
+     *
+     * @param string $key
+     * @param mixed[] $value
+     * @return void
+     */
+    public function merge(string $key, array $value): void;
+
+    /**
      * Does data exist for the specified key?
      *
      * @param string $key

--- a/tests/Config/ConfigRepositoryTest.php
+++ b/tests/Config/ConfigRepositoryTest.php
@@ -95,6 +95,21 @@ describe(
         );
 
         test(
+            'Retrieve configuration data from a specified path',
+            function () {
+                /** @var ConfigTestCase $this */
+
+                $path = dirname(__DIR__, 1) . '/resource/config/config01.php';
+
+                $expected = require $path;
+
+                $actual = ConfigPhpRepository::getConfigByPath($path);
+
+                expect($actual)->toEqual($expected);
+            }
+        );
+
+        test(
             'Settings loaded will overwrite the original settings',
             function () {
                 /** @var ConfigTestCase $this */
@@ -154,6 +169,33 @@ describe(
                 }
 
                 expect($repository->all())->toEqual($excepted);
+            },
+        )->with([
+            fn () => [
+                'hoge' => [
+                    'fuga' => 'piyo',
+                ],
+                'foo' => ['bar'],
+            ],
+            fn () => [
+                'test' => [
+                    'test' => 'test',
+                ],
+                'test01' => ['test'],
+                'test02' => ['test'],
+            ],
+        ]);
+
+        test(
+            'Merge config values',
+            function (array $expected) {
+                $repository = new ConfigPhpRepository();
+
+                foreach ($expected as $key => $value) {
+                    $repository->merge($key, $value);
+                }
+
+                expect($repository->all())->toEqual($expected);
             },
         )->with([
             fn () => [

--- a/tests/Config/ConfigRepositoryTest.php
+++ b/tests/Config/ConfigRepositoryTest.php
@@ -95,7 +95,57 @@ describe(
         );
 
         test(
-            '',
+            'Settings loaded will overwrite the original settings',
+            function () {
+                /** @var ConfigTestCase $this */
+
+                $configKeys = [
+                    'config01.foo',
+                    'config01.bar',
+                    'config01.num',
+                ];
+
+                $exceptedConfigs = [];
+
+                foreach ($configKeys as $key) {
+                    $exceptedConfigs[$key] = $this->repository->get($key);
+                }
+
+                $this->repository->load($this->getAnotherDirectoryPath(), true);
+
+                foreach ($configKeys as $key) {
+                    expect($this->repository->get($key))->not->toEqual($exceptedConfigs[$key]);
+                }
+            },
+        );
+
+        test(
+            'Loaded settings do not overwrite original settings',
+            function () {
+                /** @var ConfigTestCase $this */
+
+                $configKeys = [
+                    'config01.foo',
+                    'config01.bar',
+                    'config01.num',
+                ];
+
+                $exceptedConfigs = [];
+
+                foreach ($configKeys as $key) {
+                    $exceptedConfigs[$key] = $this->repository->get($key);
+                }
+
+                $this->repository->load($this->getAnotherDirectoryPath(), false);
+
+                foreach ($configKeys as $key) {
+                    expect($this->repository->get($key))->toEqual($exceptedConfigs[$key]);
+                }
+            },
+        );
+
+        test(
+            'Set the value of config',
             function (array $excepted) {
                 $repository = new ConfigPhpRepository();
 

--- a/tests/resource/another-config/config01.php
+++ b/tests/resource/another-config/config01.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'foo' => 'bar-override',
+    'bar' => 'baz-override',
+    'num' => 1230,
+];


### PR DESCRIPTION
In the ConfigRepository, there was no functionality to overwrite values later, so functionality was added.

The changes are as follows
1. added a flag to enable overwriting of values in the argument of the load method
2. Added a method to merge array values