### PR TITLE
Fix handler argument resolution in ControllerInvoker.

### DIFF
--- a/src/Http/Support/AbstractContext.php
+++ b/src/Http/Support/AbstractContext.php
@@ -18,10 +18,26 @@ abstract class AbstractContext
      */
     public function withContext(ServerRequestInterface $request): ServerRequestInterface
     {
-        return $request->withAttribute(
+        $request = $request->withAttribute(
             static::ContextKey,
             $this,
         );
+
+        foreach ($this->getServerRequestAttributes() as $key => $value) {
+            $request = $request->withAttribute($key, $value);
+        }
+
+        return $request;
+    }
+
+    /**
+     * Get contextual data.
+     *
+     * @return array<string,mixed>
+     */
+    protected function getServerRequestAttributes(): array
+    {
+        return [];
     }
 
     /**

--- a/tests/Http/AbstractContextTest.php
+++ b/tests/Http/AbstractContextTest.php
@@ -5,7 +5,7 @@ use Takemo101\Chubby\Http\Support\ContextException;
 use Psr\Http\Message\ServerRequestInterface;
 
 describe(
-    'abstract-context',
+    'AbstractContext',
     function () {
 
         test(
@@ -31,64 +31,73 @@ describe(
             }
         );
 
-        test('can create context instance from server request', function () {
-            $context = new class() extends AbstractContext
-            {
-                public function __construct()
+        test(
+            'can create context instance from server request',
+            function () {
+                $context = new class() extends AbstractContext
                 {
-                    // ...
-                }
-            };
-
-            $request = Mockery::mock(ServerRequestInterface::class);
-            $request->shouldReceive('getAttribute')
-                ->once()
-                ->with(AbstractContext::ContextKey)
-                ->andReturn($context);
-
-            $actual = AbstractContext::fromServerRequest($request);
-
-            expect($actual)->toBe($context);
-        });
-
-        test('throws exception when context not found', function () {
-            $request = Mockery::mock(ServerRequestInterface::class);
-            $request->shouldReceive('getAttribute')
-                ->once()
-                ->with(AbstractContext::ContextKey)
-                ->andReturn(null);
-
-            expect(function () use ($request) {
-                AbstractContext::fromServerRequest($request);
-            })->toThrow(ContextException::class);
-        });
-
-        test('throws exception when context is not an instance of the expected class', function () {
-            $context = new class()
-            {
-                public function __construct()
-                {
-                    // ...
-                }
-            };
-
-            $request = Mockery::mock(ServerRequestInterface::class);
-            $request->shouldReceive('getAttribute')
-                ->once()
-                ->with(AbstractContext::ContextKey)
-                ->andReturn($context);
-
-            expect(function () use ($request) {
-                AbstractContext::fromServerRequest($request, function () {
-                    return new class() extends AbstractContext
+                    public function __construct()
                     {
-                        public function __construct()
+                        // ...
+                    }
+                };
+
+                $request = Mockery::mock(ServerRequestInterface::class);
+                $request->shouldReceive('getAttribute')
+                    ->once()
+                    ->with(AbstractContext::ContextKey)
+                    ->andReturn($context);
+
+                $actual = AbstractContext::fromServerRequest($request);
+
+                expect($actual)->toBe($context);
+            }
+        );
+
+        test(
+            'throws exception when context not found',
+            function () {
+                $request = Mockery::mock(ServerRequestInterface::class);
+                $request->shouldReceive('getAttribute')
+                    ->once()
+                    ->with(AbstractContext::ContextKey)
+                    ->andReturn(null);
+
+                expect(function () use ($request) {
+                    AbstractContext::fromServerRequest($request);
+                })->toThrow(ContextException::class);
+            }
+        );
+
+        test(
+            'throws exception when context is not an instance of the expected class',
+            function () {
+                $context = new class()
+                {
+                    public function __construct()
+                    {
+                        // ...
+                    }
+                };
+
+                $request = Mockery::mock(ServerRequestInterface::class);
+                $request->shouldReceive('getAttribute')
+                    ->once()
+                    ->with(AbstractContext::ContextKey)
+                    ->andReturn($context);
+
+                expect(function () use ($request) {
+                    AbstractContext::fromServerRequest($request, function () {
+                        return new class() extends AbstractContext
                         {
-                            // ...
-                        }
-                    };
-                });
-            })->toThrow(ContextException::class);
-        });
+                            public function __construct()
+                            {
+                                // ...
+                            }
+                        };
+                    });
+                })->toThrow(ContextException::class);
+            }
+        );
     }
 )->group('abstract-context', 'http');


### PR DESCRIPTION
Fix handler argument resolution in ControllerInvoker.

The changes are as follows

1. added ParameterKeyTypeHintResolver class and modified the way to resolve handler arguments in ControllerInvoker.
If the parameter key is a class name, the value for the key is considered the value for the class name.
2. added a flag whether or not to overwrite the value in the merge method of ConfigRepository.
3. added getServerRequestAttributes method to allow adding other attributes to the request in the AbstractContext class.