### PR TITLE
Add delete and overwrite methods to ClassCollection

### DIFF
--- a/src/Console/Command/ServeProcessOutputHandler.php
+++ b/src/Console/Command/ServeProcessOutputHandler.php
@@ -111,10 +111,14 @@ class ServeProcessOutputHandler
                     $this->output->writeln("<fg=red;options=bold>{$line}</>");
                 }
             }
-            // Thinking as a warning message
+            // Thinking as a warning or normal message
             else {
 
-                $this->output->writeln("<fg=red;options=bold>{$line}</>");
+                $this->output->writeln(
+                    $this->isErrorLine($line)
+                        ? "<fg=red;options=bold>{$line}</>"
+                        : "<fg=yellow>{$line}</>",
+                );
             }
         }
     }
@@ -200,5 +204,34 @@ class ServeProcessOutputHandler
     private function hasRequestHostFromLine(string $line): bool
     {
         return preg_match(self::RequestHostRegex, $line) === 1;
+    }
+
+    /**
+     * Judge whether it is an error
+     *
+     * @param string $line
+     * @return boolean
+     */
+    private function isErrorLine(string $line): bool
+    {
+        $line = strtolower($line);
+
+        $errors = [
+            'error:',
+            'php fatal error:',
+            'php warning:',
+            'php notice:',
+            'php parse error:',
+            'php deprecated:',
+            'php recoverable fatal error:',
+        ];
+
+        foreach ($errors as $error) {
+            if (str_contains($line, $error)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Http/Bridge/ControllerInvoker.php
+++ b/src/Http/Bridge/ControllerInvoker.php
@@ -83,7 +83,7 @@ class ControllerInvoker implements InvocationStrategyInterface
         ResponseInterface $response,
         array $routeArguments,
     ): array {
-        $domainRouteContext = DomainRouteContext::fromServerRequest(
+        $domainRouteContext = DomainRouteContext::fromRequest(
             $request,
             fn () => new DomainRouteContext(),
         );

--- a/src/Http/Bridge/ControllerInvoker.php
+++ b/src/Http/Bridge/ControllerInvoker.php
@@ -89,7 +89,7 @@ class ControllerInvoker implements InvocationStrategyInterface
         );
 
         $routeArguments = [
-            ...$domainRouteContext->getArguments(),
+            ...($domainRouteContext?->getArguments() ?? []),
             ...$routeArguments,
         ];
 

--- a/src/Http/Support/AbstractContext.php
+++ b/src/Http/Support/AbstractContext.php
@@ -45,19 +45,19 @@ abstract class AbstractContext
      *
      * @param ServerRequestInterface $request
      * @param null|Closure():static $factory A factory function that returns a new instance of the context.
-     * @return static
+     * @return static|null
      * @throws ContextException
      */
     public static function fromRequest(
         ServerRequestInterface $request,
         ?Closure $factory = null,
-    ): static {
+    ): ?static {
         /** @var static|null */
         $context = $request->getAttribute(static::ContextKey);
 
         if (is_null($context)) {
             if (is_null($factory)) {
-                throw ContextException::notFound(static::ContextKey);
+                return null;
             }
 
             $context = $factory();

--- a/src/Http/Support/AbstractContext.php
+++ b/src/Http/Support/AbstractContext.php
@@ -48,7 +48,7 @@ abstract class AbstractContext
      * @return static
      * @throws ContextException
      */
-    public static function fromServerRequest(
+    public static function fromRequest(
         ServerRequestInterface $request,
         ?Closure $factory = null,
     ): static {

--- a/src/Support/ClassCollection.php
+++ b/src/Support/ClassCollection.php
@@ -30,10 +30,27 @@ abstract class ClassCollection
     }
 
     /**
+     * Set a class name or object of the specified type.
+     * Overwrite all classes.
+     *
+     * @param class-string<T>|T ...$classes
+     * @return static
+     * @throws RuntimeException
+     */
+    public function set(string|object ...$classes): static
+    {
+        $this->clear();
+        $this->add(...$classes);
+
+        return $this;
+    }
+
+    /**
      * Adds a class name or object of the specified type
      *
      * @param class-string<T>|T ...$classes
      * @return static
+     * @throws RuntimeException
      */
     public function add(string|object ...$classes): static
     {
@@ -72,6 +89,38 @@ abstract class ClassCollection
             ...$this->classes,
             ...$_classes,
         ];
+
+        return $this;
+    }
+
+    /**
+     * Remove a class name or object of the specified type
+     *
+     * @param class-string<T> $class
+     * @return static
+     * @throws RuntimeException
+     */
+    public function remove(string $class): static
+    {
+        if (!(
+            class_exists($class)
+            || interface_exists($class)
+        )) {
+            throw new RuntimeException(
+                sprintf(
+                    'Class "%s" does not exist.',
+                    $class,
+                ),
+            );
+        }
+
+        $this->classes = array_filter(
+            $this->classes,
+            fn ($item) => !(
+                is_a($item, $class, true) // @phpstan-ignore-line
+                || is_subclass_of($item, $class, true)
+            ),
+        );
 
         return $this;
     }

--- a/tests/Console/ServeProcessOutputHandlerTest.php
+++ b/tests/Console/ServeProcessOutputHandlerTest.php
@@ -49,13 +49,13 @@ describe(
 
             $output = m::mock(OutputInterface::class);
 
-            $output->shouldReceive('writeln')->with("<fg=red;options=bold>Invalid line</>");
+            $output->shouldReceive('writeln')->with("<fg=red;options=bold>ERROR: Invalid line</>");
 
             $handler = new ServeProcessOutputHandler(
                 output: $output,
                 requestPool: $requestPool,
             );
-            $handler('out', "Invalid line\n");
+            $handler('out', "ERROR: Invalid line\n");
 
             expect($requestPool->getRequests())->toBe([]);
         });

--- a/tests/Http/AbstractContextTest.php
+++ b/tests/Http/AbstractContextTest.php
@@ -48,7 +48,7 @@ describe(
                     ->with(AbstractContext::ContextKey)
                     ->andReturn($context);
 
-                $actual = AbstractContext::fromServerRequest($request);
+                $actual = AbstractContext::fromRequest($request);
 
                 expect($actual)->toBe($context);
             }
@@ -64,7 +64,7 @@ describe(
                     ->andReturn(null);
 
                 expect(function () use ($request) {
-                    AbstractContext::fromServerRequest($request);
+                    AbstractContext::fromRequest($request);
                 })->toThrow(ContextException::class);
             }
         );
@@ -87,7 +87,7 @@ describe(
                     ->andReturn($context);
 
                 expect(function () use ($request) {
-                    AbstractContext::fromServerRequest($request, function () {
+                    AbstractContext::fromRequest($request, function () {
                         return new class() extends AbstractContext
                         {
                             public function __construct()

--- a/tests/Http/AbstractContextTest.php
+++ b/tests/Http/AbstractContextTest.php
@@ -55,7 +55,7 @@ describe(
         );
 
         test(
-            'throws exception when context not found',
+            'return null when context not found',
             function () {
                 $request = Mockery::mock(ServerRequestInterface::class);
                 $request->shouldReceive('getAttribute')
@@ -63,9 +63,8 @@ describe(
                     ->with(AbstractContext::ContextKey)
                     ->andReturn(null);
 
-                expect(function () use ($request) {
-                    AbstractContext::fromRequest($request);
-                })->toThrow(ContextException::class);
+                expect(AbstractContext::fromRequest($request))
+                    ->toBeNull();
             }
         );
 
@@ -100,4 +99,4 @@ describe(
             }
         );
     }
-)->group('abstract-context', 'http');
+)->group('AbstractContext', 'http');

--- a/tests/Http/DomainRouteTest.php
+++ b/tests/Http/DomainRouteTest.php
@@ -60,7 +60,7 @@ describe(
                     $mock,
                 );
 
-                $context = DomainRouteContext::fromServerRequest($mock?->actualRequest);
+                $context = DomainRouteContext::fromRequest($mock?->actualRequest);
 
                 foreach ($routeArguments as $key => $argument) {
                     expect($context->getArguments()[$key])->toEqual($argument);

--- a/tests/Support/ClassCollectionTest.php
+++ b/tests/Support/ClassCollectionTest.php
@@ -67,5 +67,80 @@ describe(
 
             expect($collection->classes())->toEqual([]);
         });
+
+        it('can set classes to the collection', function () {
+            $collection = new class() extends ClassCollection
+            {
+                //
+            };
+
+            $class1 = new class() extends stdClass
+            {
+                //
+            };
+
+            $class2 = new class() extends stdClass
+            {
+                //
+            };
+
+            $collection->set(stdClass::class, $class1, $class2);
+
+            expect($collection->classes())->toEqual([
+                stdClass::class,
+                $class1,
+                $class2,
+            ]);
+        });
+
+        it('can remove a class from the collection', function () {
+            $collection = new class() extends ClassCollection
+            {
+                //
+            };
+
+            $class1 = new class() extends stdClass
+            {
+                //
+            };
+
+            $class2 = new class() extends stdClass implements Stringable
+            {
+                public function __toString(): string
+                {
+                    return 'Class2';
+                }
+            };
+
+            $collection->add(stdClass::class, $class1, $class2);
+
+            $collection->remove(Stringable::class);
+
+            expect($collection->classes())->toEqual([
+                stdClass::class,
+                $class1,
+            ]);
+        });
+
+        it('throws an exception when removing a non-existent class', function () {
+            $collection = new class() extends ClassCollection
+            {
+                //
+            };
+
+            expect(fn () => $collection->remove('NonExistentClass'))
+                ->toThrow(RuntimeException::class, 'Class "NonExistentClass" does not exist.');
+        });
+
+        it('can create an empty collection using the static method', function () {
+            $collection = new class() extends ClassCollection
+            {
+                //
+            };
+
+            $actual = $collection::empty();
+
+            expect($actual->classes())->toBe([]);
+        });
     }
 )->group('ClassCollection', 'support');


### PR DESCRIPTION
Added delete and overwrite methods to ``ClassCollection``.
The ``fromRequest`` method of the ``AbstractContext`` class now returns null if there is no target Context in the request, since it was not very useful since it only handled errors.

The changes are as follows.
1. add delete and overwrite methods to ``ClassCollection``.
2. refactor ``AbstractContext`` class
3. improve ``ServeCommand`` error output