### PR TITLE
Allow helper to define replaceable DI definitions based on class definitions set in config file.

### DIFF
--- a/config/console.php
+++ b/config/console.php
@@ -1,0 +1,10 @@
+<?php
+
+// Console configuration
+
+return [
+    // Console command class name array
+    'commands' => [
+        // class-string<SymfonyCommand>
+    ],
+];

--- a/src/Application.php
+++ b/src/Application.php
@@ -49,7 +49,7 @@ class Application implements ApplicationContainer
     /**
      * @var string
      */
-    public const Version = '0.0.22';
+    public const Version = '0.0.23';
 
     /**
      * @var Container|null

--- a/src/Application.php
+++ b/src/Application.php
@@ -24,7 +24,7 @@ use Takemo101\Chubby\Config\ConfigRepository;
 use Takemo101\Chubby\Bootstrap\Provider\Provider;
 use Takemo101\Chubby\Support\ApplicationPath;
 use Takemo101\Chubby\Support\ApplicationSummary;
-use Takemo101\Chubby\Bootstrap\Provider\BootProvider;
+use Takemo101\Chubby\Bootstrap\Provider\BootStartProvider;
 use Takemo101\Chubby\Bootstrap\Provider\ConfigProvider;
 use Takemo101\Chubby\Bootstrap\Provider\ErrorProvider;
 use Takemo101\Chubby\Bootstrap\Provider\EventProvider;
@@ -113,7 +113,7 @@ class Application implements ApplicationContainer
 
         // Add a provider that satisfies the dependencies required to run the application
         $bootstrap->addProvider(
-            new BootProvider(),
+            new BootStartProvider(),
             new EnvironmentProvider($this->path),
             new ErrorProvider(),
             new EventProvider(),

--- a/src/Bootstrap/DefinitionHelper.php
+++ b/src/Bootstrap/DefinitionHelper.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Takemo101\Chubby\Bootstrap;
+
+use Closure;
+use Psr\Container\ContainerInterface;
+use Takemo101\Chubby\Config\ConfigRepository;
+use Takemo101\Chubby\Hook\Hook;
+
+class DefinitionHelper
+{
+    /**
+     * Create a handler to create a replacement definition by obtaining the definition of the target from a configuration
+     *
+     * @template T of object
+     *
+     * @param class-string<T> $entry Entry name to be replaced
+     * @param string $configKey Configuration key to get the class name
+     * @param class-string $defaultClass Default class when there is no class to support entry
+     * @param boolean $hook Whether to hook the replacement process
+     * @return Closure
+     */
+    public static function createReplaceableDefinition(
+        string $entry,
+        string $configKey,
+        string $defaultClass,
+        bool $hook = false,
+    ): Closure {
+        return function (
+            ConfigRepository $config,
+            ContainerInterface $container,
+        ) use (
+            $entry,
+            $configKey,
+            $defaultClass,
+            $hook,
+        ) {
+            /** @var class-string<T> */
+            $class = $config->get(
+                $configKey,
+                $defaultClass,
+            );
+
+            /** @var T */
+            $instance = $container->get($class);
+
+            if ($hook) {
+                /** @var Hook */
+                $hook = $container->get(Hook::class);
+
+                $hook->do($entry, $instance);
+            }
+
+            return $instance;
+        };
+    }
+}

--- a/src/Bootstrap/Provider/BootStartProvider.php
+++ b/src/Bootstrap/Provider/BootStartProvider.php
@@ -10,9 +10,9 @@ use Takemo101\Chubby\Hook\Hook;
 use Takemo101\Chubby\Support\ServiceLocator;
 
 /**
- * Boot related.
+ * Bootstrap start related.
  */
-class BootProvider implements Provider
+class BootStartProvider implements Provider
 {
     /**
      * @var string Provider name.

--- a/src/Bootstrap/Provider/ConsoleProvider.php
+++ b/src/Bootstrap/Provider/ConsoleProvider.php
@@ -6,6 +6,8 @@ use Takemo101\Chubby\Application;
 use Takemo101\Chubby\ApplicationContainer;
 use Takemo101\Chubby\Bootstrap\Definitions;
 use Symfony\Component\Console\Application as SymfonyConsole;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Takemo101\Chubby\Config\ConfigRepository;
 use Takemo101\Chubby\Console\Command\LogCleanCommand;
 use Takemo101\Chubby\Console\Command\ServeCommand;
 use Takemo101\Chubby\Console\Command\VersionCommand;
@@ -67,9 +69,14 @@ class ConsoleProvider implements Provider
                     return $adapter;
                 },
                 CommandCollection::class => function (
+                    ConfigRepository $config,
                     Hook $hook,
                 ): CommandCollection {
-                    $commands = CommandCollection::empty();
+
+                    /** @var class-string<SymfonyCommand>[] */
+                    $classes = $config->get('console.commands', []);
+
+                    $commands = new CommandCollection(...$classes);
 
                     $hook->doTyped($commands);
 

--- a/src/Bootstrap/Provider/EventProvider.php
+++ b/src/Bootstrap/Provider/EventProvider.php
@@ -2,10 +2,10 @@
 
 namespace Takemo101\Chubby\Bootstrap\Provider;
 
-use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\EventDispatcher\ListenerProviderInterface;
 use Takemo101\Chubby\ApplicationContainer;
+use Takemo101\Chubby\Bootstrap\DefinitionHelper;
 use Takemo101\Chubby\Bootstrap\Definitions;
 use Takemo101\Chubby\Config\ConfigRepository;
 use Takemo101\Chubby\Event\EventDispatcher;
@@ -46,37 +46,16 @@ class EventProvider implements Provider
 
                     return $register;
                 },
-                EventDispatcherInterface::class => function (
-                    ConfigRepository $config,
-                    ContainerInterface $container,
-                ) {
-                    /** @var class-string<EventDispatcherInterface> */
-                    $class = $config->get(
-                        'event.dispatcher',
-                        EventDispatcher::class,
-                    );
-
-                    /** @var EventDispatcherInterface */
-                    $dispatcher = $container->get($class);
-
-                    return $dispatcher;
-                },
-                ListenerProviderInterface::class =>
-                function (
-                    ConfigRepository $config,
-                    ContainerInterface $container,
-                ) {
-                    /** @var class-string<ListenerProviderInterface> */
-                    $class = $config->get(
-                        'event.provider',
-                        EventListenerProvider::class,
-                    );
-
-                    /** @var ListenerProviderInterface */
-                    $provider = $container->get($class);
-
-                    return $provider;
-                },
+                EventDispatcherInterface::class => DefinitionHelper::createReplaceableDefinition(
+                    entry: EventDispatcherInterface::class,
+                    configKey: 'event.dispatcher',
+                    defaultClass: EventDispatcher::class,
+                ),
+                ListenerProviderInterface::class => DefinitionHelper::createReplaceableDefinition(
+                    entry: ListenerProviderInterface::class,
+                    configKey: 'event.provider',
+                    defaultClass: EventListenerProvider::class,
+                ),
             ],
         );
     }

--- a/src/Bootstrap/Provider/HttpProvider.php
+++ b/src/Bootstrap/Provider/HttpProvider.php
@@ -2,10 +2,8 @@
 
 namespace Takemo101\Chubby\Bootstrap\Provider;
 
-use DI\Definition\Definition;
 use Slim\App as Slim;
 use Nyholm\Psr7\Factory\Psr17Factory;
-use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;

--- a/src/Bootstrap/Provider/HttpProvider.php
+++ b/src/Bootstrap/Provider/HttpProvider.php
@@ -2,6 +2,7 @@
 
 namespace Takemo101\Chubby\Bootstrap\Provider;
 
+use DI\Definition\Definition;
 use Slim\App as Slim;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
@@ -20,6 +21,7 @@ use Slim\Interfaces\RouteCollectorProxyInterface;
 use Slim\Middleware\ErrorMiddleware;
 use Slim\MiddlewareDispatcher;
 use Takemo101\Chubby\ApplicationContainer;
+use Takemo101\Chubby\Bootstrap\DefinitionHelper;
 use Takemo101\Chubby\Bootstrap\Definitions;
 use Takemo101\Chubby\Config\ConfigRepository;
 use Takemo101\Chubby\Hook\Hook;
@@ -65,30 +67,16 @@ class HttpProvider implements Provider
         $definitions->add(
             [
                 InvocationStrategyInterface::class => get(ControllerInvoker::class),
-                SlimFactory::class => function (
-                    ContainerInterface $container,
-                    ConfigRepository $config,
-                ) {
-                    /** @var class-string<SlimFactory> */
-                    $class = $config->get('slim.factory', DefaultSlimFactory::class);
-
-                    /** @var SlimFactory */
-                    $factory = $container->get($class);
-
-                    return $factory;
-                },
-                SlimConfigurer::class => function (
-                    ContainerInterface $container,
-                    ConfigRepository $config,
-                ) {
-                    /** @var class-string<SlimConfigurer> */
-                    $class = $config->get('slim.configurer', DefaultSlimConfigurer::class);
-
-                    /** @var SlimConfigurer */
-                    $configurer = $container->get($class);
-
-                    return $configurer;
-                },
+                SlimFactory::class => DefinitionHelper::createReplaceableDefinition(
+                    entry: SlimFactory::class,
+                    configKey: 'slim.factory',
+                    defaultClass: DefaultSlimFactory::class,
+                ),
+                SlimConfigurer::class => DefinitionHelper::createReplaceableDefinition(
+                    entry: SlimConfigurer::class,
+                    configKey: 'slim.configurer',
+                    defaultClass: DefaultSlimConfigurer::class,
+                ),
                 Slim::class => function (
                     SlimFactory $factory,
                     Hook $hook,
@@ -152,18 +140,11 @@ class HttpProvider implements Provider
 
                     return $renders;
                 },
-                ErrorHandlerInterface::class => function (
-                    ContainerInterface $container,
-                    ConfigRepository $config,
-                ) {
-                    /** @var class-string<ErrorHandlerInterface> */
-                    $class = $config->get('slim.error.handler', ErrorHandler::class);
-
-                    /** @var ErrorHandlerInterface */
-                    $handler = $container->get($class);
-
-                    return $handler;
-                },
+                ErrorHandlerInterface::class => DefinitionHelper::createReplaceableDefinition(
+                    entry: ErrorHandlerInterface::class,
+                    configKey: 'slim.error.handler',
+                    defaultClass: ErrorHandler::class,
+                ),
                 ErrorHandler::class => function (
                     Slim $slim,
                     LoggerInterface $logger,


### PR DESCRIPTION
A helper can be defined to define a DI definition that enables replacement of the target function based on the class definition set in the config file.

The changes are as follows
1. added ``DefinitionHelper`` helper class to support DI definitions.
2. refactor of ``Provider`` class.