### PR TITLE
Fixed DefinitionHelper.

### DIFF
--- a/src/Bootstrap/DefinitionHelper.php
+++ b/src/Bootstrap/DefinitionHelper.php
@@ -48,7 +48,8 @@ class DefinitionHelper
                 /** @var Hook */
                 $hook = $container->get(Hook::class);
 
-                $hook->do($entry, $instance);
+                /** @var T */
+                $instance = $hook->do($entry, $instance);
             }
 
             return $instance;

--- a/tests/Bootstrap/DefinitionHelperTest.php
+++ b/tests/Bootstrap/DefinitionHelperTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use Psr\Container\ContainerInterface;
+use Takemo101\Chubby\Config\ConfigRepository;
+use Takemo101\Chubby\Hook\Hook;
+use Takemo101\Chubby\Bootstrap\DefinitionHelper;
+use Mockery as m;
+
+describe(
+    'DefinitionHelper',
+    function () {
+
+        beforeEach(function () {
+            $this->config = m::mock(ConfigRepository::class);
+            $this->container = m::mock(ContainerInterface::class);
+            $this->hook = m::mock(Hook::class);
+        });
+
+        afterEach(function () {
+            m::close();
+        });
+
+        it('should return a closure', function () {
+            $entry = 'MyEntry';
+            $configKey = 'my_entry_config';
+            $defaultClass = 'DefaultClass';
+            $hook = false;
+
+            $closure = DefinitionHelper::createReplaceableDefinition(
+                $entry,
+                $configKey,
+                $defaultClass,
+                $hook
+            );
+
+            expect($closure)->toBeInstanceOf(Closure::class);
+        });
+
+        it('should return the instance from the container without hooking', function () {
+            $entry = 'MyEntry';
+            $configKey = 'my_entry_config';
+            $defaultClass = 'DefaultClass';
+            $hook = false;
+
+            $class = 'MyClass';
+            $instance = new stdClass();
+
+            $this->config->shouldReceive('get')
+                ->once()
+                ->with($configKey, $defaultClass)
+                ->andReturn($class);
+
+            $this->container->shouldReceive('get')
+                ->once()
+                ->with($class)
+                ->andReturn($instance);
+
+            $closure = DefinitionHelper::createReplaceableDefinition(
+                $entry,
+                $configKey,
+                $defaultClass,
+                $hook
+            );
+
+            $result = $closure($this->config, $this->container);
+
+            expect($result)->toBe($instance);
+        });
+
+        it('should return the instance from the container with hooking', function () {
+            $entry = 'MyEntry';
+            $configKey = 'my_entry_config';
+            $defaultClass = 'DefaultClass';
+            $hook = true;
+
+            $class = 'MyClass';
+            $instance = new stdClass();
+            $hookedInstance = new stdClass();
+
+            $this->config->shouldReceive('get')
+                ->once()
+                ->with($configKey, $defaultClass)
+                ->andReturn($class);
+
+            $this->container->shouldReceive('get')
+                ->once()
+                ->with($class)
+                ->andReturn($instance);
+
+            $this->container->shouldReceive('get')
+                ->once()
+                ->with(Hook::class)
+                ->andReturn($this->hook);
+
+            $this->hook->shouldReceive('do')
+                ->once()
+                ->with($entry, $instance)
+                ->andReturn($hookedInstance);
+
+            $closure = DefinitionHelper::createReplaceableDefinition(
+                $entry,
+                $configKey,
+                $defaultClass,
+                $hook
+            );
+
+            $result = $closure($this->config, $this->container);
+
+            expect($result)->toBe($hookedInstance);
+        });
+    }
+)->group('DefinitionHelper', 'bootstrap');

--- a/tests/Bootstrap/DefinitionHelperTest.php
+++ b/tests/Bootstrap/DefinitionHelperTest.php
@@ -10,103 +10,105 @@ describe(
     'DefinitionHelper',
     function () {
 
-        beforeEach(function () {
-            $this->config = m::mock(ConfigRepository::class);
-            $this->container = m::mock(ContainerInterface::class);
-            $this->hook = m::mock(Hook::class);
-        });
+        describe(
+            'createReplaceableDefinition',
+            function () {
 
-        afterEach(function () {
-            m::close();
-        });
+                beforeEach(function () {
+                    $this->config = m::mock(ConfigRepository::class);
+                    $this->container = m::mock(ContainerInterface::class);
+                    $this->hook = m::mock(Hook::class);
+                });
 
-        it('should return a closure', function () {
-            $entry = 'MyEntry';
-            $configKey = 'my_entry_config';
-            $defaultClass = 'DefaultClass';
-            $hook = false;
+                it('should return a closure', function () {
+                    $entry = 'MyEntry';
+                    $configKey = 'my_entry_config';
+                    $defaultClass = 'DefaultClass';
+                    $hook = false;
 
-            $closure = DefinitionHelper::createReplaceableDefinition(
-                $entry,
-                $configKey,
-                $defaultClass,
-                $hook
-            );
+                    $closure = DefinitionHelper::createReplaceableDefinition(
+                        $entry,
+                        $configKey,
+                        $defaultClass,
+                        $hook
+                    );
 
-            expect($closure)->toBeInstanceOf(Closure::class);
-        });
+                    expect($closure)->toBeInstanceOf(Closure::class);
+                });
 
-        it('should return the instance from the container without hooking', function () {
-            $entry = 'MyEntry';
-            $configKey = 'my_entry_config';
-            $defaultClass = 'DefaultClass';
-            $hook = false;
+                it('should return the instance from the container without hooking', function () {
+                    $entry = 'MyEntry';
+                    $configKey = 'my_entry_config';
+                    $defaultClass = 'DefaultClass';
+                    $hook = false;
 
-            $class = 'MyClass';
-            $instance = new stdClass();
+                    $class = 'MyClass';
+                    $instance = new stdClass();
 
-            $this->config->shouldReceive('get')
-                ->once()
-                ->with($configKey, $defaultClass)
-                ->andReturn($class);
+                    $this->config->shouldReceive('get')
+                        ->once()
+                        ->with($configKey, $defaultClass)
+                        ->andReturn($class);
 
-            $this->container->shouldReceive('get')
-                ->once()
-                ->with($class)
-                ->andReturn($instance);
+                    $this->container->shouldReceive('get')
+                        ->once()
+                        ->with($class)
+                        ->andReturn($instance);
 
-            $closure = DefinitionHelper::createReplaceableDefinition(
-                $entry,
-                $configKey,
-                $defaultClass,
-                $hook
-            );
+                    $closure = DefinitionHelper::createReplaceableDefinition(
+                        $entry,
+                        $configKey,
+                        $defaultClass,
+                        $hook
+                    );
 
-            $result = $closure($this->config, $this->container);
+                    $result = $closure($this->config, $this->container);
 
-            expect($result)->toBe($instance);
-        });
+                    expect($result)->toBe($instance);
+                });
 
-        it('should return the instance from the container with hooking', function () {
-            $entry = 'MyEntry';
-            $configKey = 'my_entry_config';
-            $defaultClass = 'DefaultClass';
-            $hook = true;
+                it('should return the instance from the container with hooking', function () {
+                    $entry = 'MyEntry';
+                    $configKey = 'my_entry_config';
+                    $defaultClass = 'DefaultClass';
+                    $hook = true;
 
-            $class = 'MyClass';
-            $instance = new stdClass();
-            $hookedInstance = new stdClass();
+                    $class = 'MyClass';
+                    $instance = new stdClass();
+                    $hookedInstance = new stdClass();
 
-            $this->config->shouldReceive('get')
-                ->once()
-                ->with($configKey, $defaultClass)
-                ->andReturn($class);
+                    $this->config->shouldReceive('get')
+                        ->once()
+                        ->with($configKey, $defaultClass)
+                        ->andReturn($class);
 
-            $this->container->shouldReceive('get')
-                ->once()
-                ->with($class)
-                ->andReturn($instance);
+                    $this->container->shouldReceive('get')
+                        ->once()
+                        ->with($class)
+                        ->andReturn($instance);
 
-            $this->container->shouldReceive('get')
-                ->once()
-                ->with(Hook::class)
-                ->andReturn($this->hook);
+                    $this->container->shouldReceive('get')
+                        ->once()
+                        ->with(Hook::class)
+                        ->andReturn($this->hook);
 
-            $this->hook->shouldReceive('do')
-                ->once()
-                ->with($entry, $instance)
-                ->andReturn($hookedInstance);
+                    $this->hook->shouldReceive('do')
+                        ->once()
+                        ->with($entry, $instance)
+                        ->andReturn($hookedInstance);
 
-            $closure = DefinitionHelper::createReplaceableDefinition(
-                $entry,
-                $configKey,
-                $defaultClass,
-                $hook
-            );
+                    $closure = DefinitionHelper::createReplaceableDefinition(
+                        $entry,
+                        $configKey,
+                        $defaultClass,
+                        $hook
+                    );
 
-            $result = $closure($this->config, $this->container);
+                    $result = $closure($this->config, $this->container);
 
-            expect($result)->toBe($hookedInstance);
-        });
+                    expect($result)->toBe($hookedInstance);
+                });
+            }
+        )->group('DefinitionHelper', 'bootstrap');
     }
-)->group('DefinitionHelper', 'bootstrap');
+);

--- a/tests/Bootstrap/DefinitionHelperTest.php
+++ b/tests/Bootstrap/DefinitionHelperTest.php
@@ -6,109 +6,104 @@ use Takemo101\Chubby\Hook\Hook;
 use Takemo101\Chubby\Bootstrap\DefinitionHelper;
 use Mockery as m;
 
+
 describe(
-    'DefinitionHelper',
+    'DefinitionHelper::createReplaceableDefinition',
     function () {
 
-        describe(
-            'createReplaceableDefinition',
-            function () {
+        beforeEach(function () {
+            $this->config = m::mock(ConfigRepository::class);
+            $this->container = m::mock(ContainerInterface::class);
+            $this->hook = m::mock(Hook::class);
+        });
 
-                beforeEach(function () {
-                    $this->config = m::mock(ConfigRepository::class);
-                    $this->container = m::mock(ContainerInterface::class);
-                    $this->hook = m::mock(Hook::class);
-                });
+        it('should return a closure', function () {
+            $entry = 'MyEntry';
+            $configKey = 'my_entry_config';
+            $defaultClass = 'DefaultClass';
+            $hook = false;
 
-                it('should return a closure', function () {
-                    $entry = 'MyEntry';
-                    $configKey = 'my_entry_config';
-                    $defaultClass = 'DefaultClass';
-                    $hook = false;
+            $closure = DefinitionHelper::createReplaceableDefinition(
+                $entry,
+                $configKey,
+                $defaultClass,
+                $hook
+            );
 
-                    $closure = DefinitionHelper::createReplaceableDefinition(
-                        $entry,
-                        $configKey,
-                        $defaultClass,
-                        $hook
-                    );
+            expect($closure)->toBeInstanceOf(Closure::class);
+        });
 
-                    expect($closure)->toBeInstanceOf(Closure::class);
-                });
+        it('should return the instance from the container without hooking', function () {
+            $entry = 'MyEntry';
+            $configKey = 'my_entry_config';
+            $defaultClass = 'DefaultClass';
+            $hook = false;
 
-                it('should return the instance from the container without hooking', function () {
-                    $entry = 'MyEntry';
-                    $configKey = 'my_entry_config';
-                    $defaultClass = 'DefaultClass';
-                    $hook = false;
+            $class = 'MyClass';
+            $instance = new stdClass();
 
-                    $class = 'MyClass';
-                    $instance = new stdClass();
+            $this->config->shouldReceive('get')
+                ->once()
+                ->with($configKey, $defaultClass)
+                ->andReturn($class);
 
-                    $this->config->shouldReceive('get')
-                        ->once()
-                        ->with($configKey, $defaultClass)
-                        ->andReturn($class);
+            $this->container->shouldReceive('get')
+                ->once()
+                ->with($class)
+                ->andReturn($instance);
 
-                    $this->container->shouldReceive('get')
-                        ->once()
-                        ->with($class)
-                        ->andReturn($instance);
+            $closure = DefinitionHelper::createReplaceableDefinition(
+                $entry,
+                $configKey,
+                $defaultClass,
+                $hook
+            );
 
-                    $closure = DefinitionHelper::createReplaceableDefinition(
-                        $entry,
-                        $configKey,
-                        $defaultClass,
-                        $hook
-                    );
+            $result = $closure($this->config, $this->container);
 
-                    $result = $closure($this->config, $this->container);
+            expect($result)->toBe($instance);
+        });
 
-                    expect($result)->toBe($instance);
-                });
+        it('should return the instance from the container with hooking', function () {
+            $entry = 'MyEntry';
+            $configKey = 'my_entry_config';
+            $defaultClass = 'DefaultClass';
+            $hook = true;
 
-                it('should return the instance from the container with hooking', function () {
-                    $entry = 'MyEntry';
-                    $configKey = 'my_entry_config';
-                    $defaultClass = 'DefaultClass';
-                    $hook = true;
+            $class = 'MyClass';
+            $instance = new stdClass();
+            $hookedInstance = new stdClass();
 
-                    $class = 'MyClass';
-                    $instance = new stdClass();
-                    $hookedInstance = new stdClass();
+            $this->config->shouldReceive('get')
+                ->once()
+                ->with($configKey, $defaultClass)
+                ->andReturn($class);
 
-                    $this->config->shouldReceive('get')
-                        ->once()
-                        ->with($configKey, $defaultClass)
-                        ->andReturn($class);
+            $this->container->shouldReceive('get')
+                ->once()
+                ->with($class)
+                ->andReturn($instance);
 
-                    $this->container->shouldReceive('get')
-                        ->once()
-                        ->with($class)
-                        ->andReturn($instance);
+            $this->container->shouldReceive('get')
+                ->once()
+                ->with(Hook::class)
+                ->andReturn($this->hook);
 
-                    $this->container->shouldReceive('get')
-                        ->once()
-                        ->with(Hook::class)
-                        ->andReturn($this->hook);
+            $this->hook->shouldReceive('do')
+                ->once()
+                ->with($entry, $instance)
+                ->andReturn($hookedInstance);
 
-                    $this->hook->shouldReceive('do')
-                        ->once()
-                        ->with($entry, $instance)
-                        ->andReturn($hookedInstance);
+            $closure = DefinitionHelper::createReplaceableDefinition(
+                $entry,
+                $configKey,
+                $defaultClass,
+                $hook
+            );
 
-                    $closure = DefinitionHelper::createReplaceableDefinition(
-                        $entry,
-                        $configKey,
-                        $defaultClass,
-                        $hook
-                    );
+            $result = $closure($this->config, $this->container);
 
-                    $result = $closure($this->config, $this->container);
-
-                    expect($result)->toBe($hookedInstance);
-                });
-            }
-        )->group('DefinitionHelper', 'bootstrap');
+            expect($result)->toBe($hookedInstance);
+        });
     }
-);
+)->group('DefinitionHelper', 'bootstrap');


### PR DESCRIPTION
Enable the ``DefinitionHelper::createReplaceableDefinition`` method hook processing flag to get the return value from the hook.