### PR TITLE
Refactoring DomainRouter

### DIFF
--- a/setting/function.php
+++ b/setting/function.php
@@ -3,12 +3,12 @@
 // Executed after DI container dependency settings are completed.
 // Here, mainly configure routing and middleware.
 
+use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Slim\Exception\HttpNotFoundException;
 use Slim\Interfaces\RouteCollectorProxyInterface;
 use Takemo101\Chubby\Filesystem\LocalFilesystem;
-use Takemo101\Chubby\Http\Configurer\SlimConfigurer;
 use Takemo101\Chubby\Http\Context;
 use Takemo101\Chubby\Http\DomainRouter;
 use Takemo101\Chubby\Http\Factory\SlimFactory;
@@ -131,38 +131,28 @@ hook()
         },
     )
     ->onTyped(
-        function (DomainRouter $router) {
-            $router->route(
-                'localhost',
-                fn (
-                    SlimHttpAdapter $http,
-                ) => $http,
-            )->setName('base');
+        function (DomainRouter $router, ContainerInterface $container) {
 
-            $router->route(
-                '{domain}.localhost',
-                function (
-                    SlimFactory $factory,
-                    SlimConfigurer $configurer,
-                ) {
-                    $slim = $factory->create();
+            /** @var SlimFactory */
+            $factory = $container->get(SlimFactory::class);
 
-                    $slim->get(
-                        '/',
-                        function (
-                            ResponseInterface $response,
-                            string $domain,
-                        ) {
-                            $response
-                                ->getBody()
-                                ->write("Hello {$domain}!");
+            /** @var SlimHttpAdapter */
+            $http = $container->get(SlimHttpAdapter::class);
 
-                            return $response;
-                        },
-                    );
+            $slim = $factory->create();
 
-                    return $configurer->configure($slim);
-                }
-            )->setName('domain');
+            $slim->get(
+                '/',
+                function (ResponseInterface $response, string $domain) {
+                    $response
+                        ->getBody()
+                        ->write("Hello {$domain}!");
+
+                    return $response;
+                },
+            );
+
+            $router->mount('localhost', $http)->setName('base');
+            $router->mount('{domain}.localhost', $slim)->setName('domain');
         },
     );

--- a/setting/function.php
+++ b/setting/function.php
@@ -16,12 +16,12 @@ use Takemo101\Chubby\Http\Middleware\DomainRouting;
 use Takemo101\Chubby\Http\Renderer\HtmlRenderer;
 use Takemo101\Chubby\Http\Renderer\JsonRenderer;
 use Takemo101\Chubby\Http\Renderer\StaticRenderer;
-use Takemo101\Chubby\Http\SlimHttpAdapter;
+use Takemo101\Chubby\Http\SlimHttp;
 use Takemo101\Chubby\Support\ApplicationPath;
 
 hook()
     ->onTyped(
-        function (SlimHttpAdapter $http) {
+        function (SlimHttp $http) {
 
             $http->get(
                 '/',
@@ -136,8 +136,8 @@ hook()
             /** @var SlimFactory */
             $factory = $container->get(SlimFactory::class);
 
-            /** @var SlimHttpAdapter */
-            $http = $container->get(SlimHttpAdapter::class);
+            /** @var SlimHttp */
+            $http = $container->get(SlimHttp::class);
 
             $slim = $factory->create();
 

--- a/src/Bootstrap/DefinitionHelper.php
+++ b/src/Bootstrap/DefinitionHelper.php
@@ -20,7 +20,7 @@ class DefinitionHelper
      * @param boolean $hook Whether to hook the replacement process
      * @return Closure
      */
-    public static function createReplaceableDefinition(
+    public static function createReplaceable(
         string $entry,
         string $configKey,
         string $defaultClass,

--- a/src/Bootstrap/Provider/ConsoleProvider.php
+++ b/src/Bootstrap/Provider/ConsoleProvider.php
@@ -5,7 +5,7 @@ namespace Takemo101\Chubby\Bootstrap\Provider;
 use Takemo101\Chubby\Application;
 use Takemo101\Chubby\ApplicationContainer;
 use Takemo101\Chubby\Bootstrap\Definitions;
-use Symfony\Component\Console\Application as SymfonyConsole;
+use Symfony\Component\Console\Application as Console;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Takemo101\Chubby\Config\ConfigRepository;
 use Takemo101\Chubby\Console\Command\LogCleanCommand;
@@ -13,7 +13,7 @@ use Takemo101\Chubby\Console\Command\ServeCommand;
 use Takemo101\Chubby\Console\Command\VersionCommand;
 use Takemo101\Chubby\Console\CommandCollection;
 use Takemo101\Chubby\Console\CommandResolver;
-use Takemo101\Chubby\Console\SymfonyConsoleAdapter;
+use Takemo101\Chubby\Console\SymfonyConsole;
 use Takemo101\Chubby\Hook\Hook;
 
 /**
@@ -36,8 +36,8 @@ class ConsoleProvider implements Provider
     {
         $definitions->add(
             [
-                SymfonyConsole::class => function (): SymfonyConsole {
-                    $console = new SymfonyConsole(
+                Console::class => function (): Console {
+                    $console = new Console(
                         Application::Name,
                         Application::Version,
                     );
@@ -46,13 +46,13 @@ class ConsoleProvider implements Provider
 
                     return $console;
                 },
-                SymfonyConsoleAdapter::class => function (
-                    SymfonyConsole $console,
+                SymfonyConsole::class => function (
+                    Console $console,
                     CommandCollection $commands,
                     CommandResolver $resolver,
                     Hook $hook,
-                ): SymfonyConsoleAdapter {
-                    $adapter = new SymfonyConsoleAdapter(
+                ): SymfonyConsole {
+                    $adapter = new SymfonyConsole(
                         application: $console,
                         commands: $commands,
                         resolver: $resolver,

--- a/src/Bootstrap/Provider/EventProvider.php
+++ b/src/Bootstrap/Provider/EventProvider.php
@@ -46,12 +46,12 @@ class EventProvider implements Provider
 
                     return $register;
                 },
-                EventDispatcherInterface::class => DefinitionHelper::createReplaceableDefinition(
+                EventDispatcherInterface::class => DefinitionHelper::createReplaceable(
                     entry: EventDispatcherInterface::class,
                     configKey: 'event.dispatcher',
                     defaultClass: EventDispatcher::class,
                 ),
-                ListenerProviderInterface::class => DefinitionHelper::createReplaceableDefinition(
+                ListenerProviderInterface::class => DefinitionHelper::createReplaceable(
                     entry: ListenerProviderInterface::class,
                     configKey: 'event.provider',
                     defaultClass: EventListenerProvider::class,

--- a/src/Bootstrap/Provider/HttpProvider.php
+++ b/src/Bootstrap/Provider/HttpProvider.php
@@ -65,12 +65,12 @@ class HttpProvider implements Provider
         $definitions->add(
             [
                 InvocationStrategyInterface::class => get(ControllerInvoker::class),
-                SlimFactory::class => DefinitionHelper::createReplaceableDefinition(
+                SlimFactory::class => DefinitionHelper::createReplaceable(
                     entry: SlimFactory::class,
                     configKey: 'slim.factory',
                     defaultClass: DefaultSlimFactory::class,
                 ),
-                SlimConfigurer::class => DefinitionHelper::createReplaceableDefinition(
+                SlimConfigurer::class => DefinitionHelper::createReplaceable(
                     entry: SlimConfigurer::class,
                     configKey: 'slim.configurer',
                     defaultClass: DefaultSlimConfigurer::class,
@@ -138,7 +138,7 @@ class HttpProvider implements Provider
 
                     return $renders;
                 },
-                ErrorHandlerInterface::class => DefinitionHelper::createReplaceableDefinition(
+                ErrorHandlerInterface::class => DefinitionHelper::createReplaceable(
                     entry: ErrorHandlerInterface::class,
                     configKey: 'slim.error.handler',
                     defaultClass: ErrorHandler::class,

--- a/src/Bootstrap/Provider/HttpProvider.php
+++ b/src/Bootstrap/Provider/HttpProvider.php
@@ -39,7 +39,7 @@ use Takemo101\Chubby\Http\ResponseTransformer\ResponseTransformers;
 use Takemo101\Chubby\Http\ResponseTransformer\StringableTransformer;
 use Takemo101\Chubby\Http\Routing\DomainRouteCollector;
 use Takemo101\Chubby\Http\Routing\DomainRouteHandler;
-use Takemo101\Chubby\Http\SlimHttpAdapter;
+use Takemo101\Chubby\Http\SlimHttp;
 
 use function DI\get;
 use function DI\create;
@@ -87,12 +87,12 @@ class HttpProvider implements Provider
                     return $slim;
                 },
                 RouteCollectorProxyInterface::class => get(Slim::class),
-                SlimHttpAdapter::class => function (
+                SlimHttp::class => function (
                     Slim $slim,
                     SlimConfigurer $configurer,
                     Hook $hook,
-                ): SlimHttpAdapter {
-                    $adapter = new SlimHttpAdapter(
+                ): SlimHttp {
+                    $adapter = new SlimHttp(
                         application: $slim,
                         configurer: $configurer,
                     );

--- a/src/Console.php
+++ b/src/Console.php
@@ -5,7 +5,7 @@ namespace Takemo101\Chubby;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Takemo101\Chubby\Console\SymfonyConsoleAdapter;
+use Takemo101\Chubby\Console\SymfonyConsole;
 use Takemo101\Chubby\Support\AbstractRunner;
 
 /**
@@ -16,15 +16,15 @@ class Console extends AbstractRunner
     /**
      * Create an console instance.
      *
-     * @return SymfonyConsoleAdapter
+     * @return SymfonyConsole
      */
-    private function getConsole(): SymfonyConsoleAdapter
+    private function getConsole(): SymfonyConsole
     {
         $this->getApp()->boot();
 
-        /** @var SymfonyConsoleAdapter */
+        /** @var SymfonyConsole */
         $console = $this->getApp()->get(
-            SymfonyConsoleAdapter::class,
+            SymfonyConsole::class,
         );
 
         return $console;

--- a/src/Console/SymfonyConsole.php
+++ b/src/Console/SymfonyConsole.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 
-class SymfonyConsoleAdapter
+class SymfonyConsole
 {
     /**
      * constructor

--- a/src/Console/SymfonyConsoleAdapter.php
+++ b/src/Console/SymfonyConsoleAdapter.php
@@ -48,7 +48,7 @@ class SymfonyConsoleAdapter
      */
     public function findCommand(string $name): Command
     {
-        $this->submitCommands();
+        $this->addCommandsToApplication();
 
         return $this->application->find($name);
     }
@@ -64,7 +64,7 @@ class SymfonyConsoleAdapter
         ?InputInterface $input = null,
         ?OutputInterface $output = null,
     ): int {
-        $this->submitCommands();
+        $this->addCommandsToApplication();
 
         return $this->application->run($input, $output);
     }
@@ -80,17 +80,17 @@ class SymfonyConsoleAdapter
         InputInterface $input,
         OutputInterface $output,
     ): int {
-        $this->submitCommands();
+        $this->addCommandsToApplication();
 
         return $this->application->doRun($input, $output);
     }
 
     /**
-     * Submit commands
+     * Add all commands to the application
      *
      * @return void
      */
-    private function submitCommands(): void
+    private function addCommandsToApplication(): void
     {
         foreach ($this->commands->classes() as $command) {
             $resolved = $this->resolver->resolve($command);

--- a/src/Http.php
+++ b/src/Http.php
@@ -10,7 +10,7 @@ use Psr\Http\Server\MiddlewareInterface;
 use Slim\Interfaces\RouteInterface;
 use Slim\Interfaces\RouteGroupInterface;
 use Slim\Interfaces\RouteCollectorProxyInterface;
-use Takemo101\Chubby\Http\SlimHttpAdapter;
+use Takemo101\Chubby\Http\SlimHttp;
 use Takemo101\Chubby\Support\AbstractRunner;
 
 /**
@@ -36,14 +36,14 @@ class Http extends AbstractRunner
     /**
      * Create an slim instance.
      *
-     * @return SlimHttpAdapter
+     * @return SlimHttp
      */
-    private function getHttp(): SlimHttpAdapter
+    private function getHttp(): SlimHttp
     {
         $this->getApp()->boot();
 
-        /** @var SlimHttpAdapter */
-        $slim = $this->getApp()->get(SlimHttpAdapter::class);
+        /** @var SlimHttp */
+        $slim = $this->getApp()->get(SlimHttp::class);
 
         return $slim;
     }
@@ -71,7 +71,7 @@ class Http extends AbstractRunner
     }
 
     /**
-     * Call method from SlimHttpAdapter.
+     * Call method from SlimHttp.
      *
      * @param string $name
      * @param mixed[] $arguments

--- a/src/Http/DomainRouter.php
+++ b/src/Http/DomainRouter.php
@@ -5,13 +5,14 @@ namespace Takemo101\Chubby\Http;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use Slim\Factory\ServerRequestCreatorFactory;
 use Slim\Interfaces\MiddlewareDispatcherInterface;
 use Slim\ResponseEmitter;
 use Takemo101\Chubby\Http\Routing\DomainRoute;
 use Takemo101\Chubby\Http\Routing\DomainRouteCollector;
 
-class DomainRouter
+class DomainRouter implements RequestHandlerInterface
 {
     /**
      * constructor
@@ -42,13 +43,13 @@ class DomainRouter
     }
 
     /**
-     * Add a route
+     * Add a route from a request handler
      *
      * @param string $pattern
-     * @param callable $handler
+     * @param RequestHandlerInterface $handler
      * @return DomainRoute
      */
-    public function route(string $pattern, callable $handler): DomainRoute
+    public function mount(string $pattern, RequestHandlerInterface $handler): DomainRoute
     {
         return $this->routeCollector->addRoute($pattern, $handler);
     }
@@ -73,10 +74,7 @@ class DomainRouter
     }
 
     /**
-     * Handle a request
-     *
-     * @param ServerRequestInterface $request
-     * @return ResponseInterface
+     * {@inheritDoc}
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {

--- a/src/Http/Routing/DomainRoute.php
+++ b/src/Http/Routing/DomainRoute.php
@@ -3,35 +3,25 @@
 namespace Takemo101\Chubby\Http\Routing;
 
 use InvalidArgumentException;
-use Closure;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 class DomainRoute
 {
     /**
-     * @var Closure
-     */
-    private readonly Closure $handler;
-
-    /**
      * constructor
      *
      * @param string $pattern
-     * @param callable(ServerRequestInterface):RequestHandlerInterface $handler
+     * @param RequestHandlerInterface $handler
+     * @param string|null $name
      */
     public function __construct(
         private readonly string $pattern,
-        callable $handler,
+        private readonly RequestHandlerInterface $handler,
         private ?string $name = null,
     ) {
         if (empty($pattern)) {
             throw new InvalidArgumentException('pattern is empty');
         }
-
-        $this->handler = $handler instanceof Closure
-            ? $handler
-            : Closure::fromCallable($handler);
     }
 
     /**
@@ -45,11 +35,11 @@ class DomainRoute
     }
 
     /**
-     * Get route handler
+     * Get route request handler
      *
-     * @return Closure
+     * @return RequestHandlerInterface
      */
-    public function getHandler(): Closure
+    public function getRequestHandler(): RequestHandlerInterface
     {
         return $this->handler;
     }

--- a/src/Http/Routing/DomainRouteCollector.php
+++ b/src/Http/Routing/DomainRouteCollector.php
@@ -2,7 +2,6 @@
 
 namespace Takemo101\Chubby\Http\Routing;
 
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 class DomainRouteCollector
@@ -15,7 +14,7 @@ class DomainRouteCollector
     /**
      * constructor
      *
-     * @param array<string,callable> $routes
+     * @param array<string,RequestHandlerInterface> $routes
      */
     public function __construct(
         array $routes = [],
@@ -29,10 +28,10 @@ class DomainRouteCollector
      * Add a route
      *
      * @param string $pattern
-     * @param callable(ServerRequestInterface):RequestHandlerInterface $handler
+     * @param RequestHandlerInterface $handler
      * @return DomainRoute
      */
-    public function addRoute(string $pattern, callable $handler): DomainRoute
+    public function addRoute(string $pattern, RequestHandlerInterface $handler): DomainRoute
     {
         $route = new DomainRoute($pattern, $handler);
 

--- a/src/Http/Routing/DomainRouteContext.php
+++ b/src/Http/Routing/DomainRouteContext.php
@@ -7,7 +7,7 @@ use Takemo101\Chubby\Http\Support\AbstractContext;
 class DomainRouteContext extends AbstractContext
 {
     /** @var string */
-    public const ContextKey = '__domain__';
+    public const ContextKey = self::class;
 
     /**
      * @var array<string,string>

--- a/src/Http/Routing/DomainRouteDispatcher.php
+++ b/src/Http/Routing/DomainRouteDispatcher.php
@@ -34,11 +34,12 @@ class DomainRouteDispatcher
         $dispatcher = simpleDispatcher(
             function (RouteCollector $r) {
                 $routes = $this->routeCollector->getRoutes();
+
                 foreach ($routes as $route) {
                     $r->addRoute(
                         self::CommonRequestMethod,
                         $route->getPattern(),
-                        $route->getHandler(),
+                        $route,
                     );
                 }
             },
@@ -47,18 +48,18 @@ class DomainRouteDispatcher
         $info = $dispatcher->dispatch(self::CommonRequestMethod, $domain);
 
         /** @var integer */
-        $routeStatus = $info[0] ?? Dispatcher::NOT_FOUND;
+        $status = $info[0] ?? Dispatcher::NOT_FOUND;
 
-        /** @var callable */
-        $routeHandler = $info[1] ?? DomainRouteHandleException::createThrowHandler();
+        /** @var DomainRoute|null */
+        $route = $info[1] ?? null;
 
         /** @var array<string,string> */
-        $routeArguments = $info[2] ?? [];
+        $arguments = $info[2] ?? [];
 
         return new DomainRouteResult(
-            found: $routeStatus === Dispatcher::FOUND,
-            handler: $routeHandler,
-            arguments: $routeArguments,
+            found: $status === Dispatcher::FOUND,
+            route: $route,
+            arguments: $arguments,
         );
     }
 
@@ -73,7 +74,7 @@ class DomainRouteDispatcher
         return new self(
             new DomainRouteCollector(
                 routes: [
-                    $domain => fn () => DomainRouteHandleException::createThrowHandler(),
+                    $domain => DomainRouteHandleException::createNeverRequestHandler(),
                 ],
             ),
         );

--- a/src/Http/Routing/DomainRouteHandleException.php
+++ b/src/Http/Routing/DomainRouteHandleException.php
@@ -4,7 +4,9 @@ namespace Takemo101\Chubby\Http\Routing;
 
 use RuntimeException;
 use Throwable;
-use Closure;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 
 class DomainRouteHandleException extends RuntimeException
 {
@@ -24,12 +26,21 @@ class DomainRouteHandleException extends RuntimeException
     }
 
     /**
-     * Create a closure that throws an exception.
+     * Create a throw exception request handler.
+     * This is used when a route is not found.
      *
-     * @return Closure
+     * @return RequestHandlerInterface
      */
-    public static function createThrowHandler(): Closure
+    public static function createNeverRequestHandler(): RequestHandlerInterface
     {
-        return fn () => throw new self();
+        return new class () implements RequestHandlerInterface {
+            /**
+             * {@inheritDoc}
+             */
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                throw new DomainRouteHandleException();
+            }
+        };
     }
 }

--- a/src/Http/Routing/DomainRouteHandler.php
+++ b/src/Http/Routing/DomainRouteHandler.php
@@ -2,7 +2,6 @@
 
 namespace Takemo101\Chubby\Http\Routing;
 
-use Invoker\InvokerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -14,11 +13,9 @@ class DomainRouteHandler implements RequestHandlerInterface
      * constructor
      *
      * @param DomainRouteDispatcher $dispatcher
-     * @param InvokerInterface $invoker
      */
     public function __construct(
         private DomainRouteDispatcher $dispatcher,
-        private InvokerInterface $invoker,
     ) {
         //
     }
@@ -40,33 +37,10 @@ class DomainRouteHandler implements RequestHandlerInterface
         /** @var DomainRouteResult */
         $routedResult = $results[1];
 
-        $handler = $this->invokeRoute(
-            $routedResult,
-            $routedRequest,
+        $route = $routedResult->getRoute();
+
+        return $route->getRequestHandler()->handle(
+            $routedRequest
         );
-
-        return $handler->handle($routedRequest);
-    }
-
-    /**
-     * Invoke routed result.
-     *
-     * @param DomainRouteResult $routedResult
-     * @param ServerRequestInterface $routedRequest
-     * @return RequestHandlerInterface
-     */
-    private function invokeRoute(
-        DomainRouteResult $routedResult,
-        ServerRequestInterface $routedRequest,
-    ): RequestHandlerInterface {
-        /** @var RequestHandlerInterface */
-        $handler = $this->invoker->call(
-            $routedResult->getHandler(),
-            [
-                'request' => $routedRequest,
-            ],
-        );
-
-        return $handler;
     }
 }

--- a/src/Http/Routing/DomainRouteResult.php
+++ b/src/Http/Routing/DomainRouteResult.php
@@ -2,7 +2,8 @@
 
 namespace Takemo101\Chubby\Http\Routing;
 
-use Closure;
+use RuntimeException;
+use InvalidArgumentException;
 
 /**
  * Result of dispatch by DomainRouteDispatcher
@@ -10,25 +11,21 @@ use Closure;
 class DomainRouteResult
 {
     /**
-     * @var Closure
-     */
-    private Closure $handler;
-
-    /**
      * constructor
      *
      * @param boolean $found
-     * @param callable $handler
+     * @param DomainRoute|null $route
      * @param array<string,string> $arguments
+     * @throws InvalidArgumentException
      */
     public function __construct(
         private bool $found,
-        callable $handler,
+        private ?DomainRoute $route = null,
         private array $arguments = []
     ) {
-        $this->handler = $handler instanceof Closure
-            ? $handler
-            : Closure::fromCallable($handler);
+        if ($found && !$route) {
+            throw new InvalidArgumentException('route is required');
+        }
     }
 
     /**
@@ -56,12 +53,18 @@ class DomainRouteResult
     }
 
     /**
-     * Get the handler of the found route.
+     * Get the found route.
+     * If the route is not found, an exception will be thrown.
      *
-     * @return Closure
+     * @return DomainRoute
+     * @throws RuntimeException
      */
-    public function getHandler(): Closure
+    public function getRoute(): DomainRoute
     {
-        return $this->handler;
+        if (!$this->route) {
+            throw new RuntimeException('route is not found');
+        }
+
+        return $this->route;
     }
 }

--- a/src/Http/SlimHttp.php
+++ b/src/Http/SlimHttp.php
@@ -9,7 +9,7 @@ use Slim\App as Slim;
 use Takemo101\Chubby\Http\Concern\HasRouting;
 use Takemo101\Chubby\Http\Configurer\SlimConfigurer;
 
-class SlimHttpAdapter implements RequestHandlerInterface
+class SlimHttp implements RequestHandlerInterface
 {
     use HasRouting;
 

--- a/src/Support/ServiceLocator.php
+++ b/src/Support/ServiceLocator.php
@@ -9,7 +9,7 @@ use Takemo101\Chubby\ApplicationContainer;
 use Takemo101\Chubby\Config\ConfigRepository;
 use Takemo101\Chubby\Console\SymfonyConsoleAdapter;
 use Takemo101\Chubby\Hook\Hook;
-use Takemo101\Chubby\Http\SlimHttpAdapter;
+use Takemo101\Chubby\Http\SlimHttp;
 
 /**
  * Have global access to your application's services
@@ -119,12 +119,12 @@ class ServiceLocator
     /**
      * Get http application.
      *
-     * @return SlimHttpAdapter
+     * @return SlimHttp
      */
-    public static function http(): SlimHttpAdapter
+    public static function http(): SlimHttp
     {
-        /** @var SlimHttpAdapter */
-        $http = self::container()->get(SlimHttpAdapter::class);
+        /** @var SlimHttp */
+        $http = self::container()->get(SlimHttp::class);
 
         return $http;
     }

--- a/src/Support/ServiceLocator.php
+++ b/src/Support/ServiceLocator.php
@@ -7,7 +7,7 @@ use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Takemo101\Chubby\ApplicationContainer;
 use Takemo101\Chubby\Config\ConfigRepository;
-use Takemo101\Chubby\Console\SymfonyConsoleAdapter;
+use Takemo101\Chubby\Console\SymfonyConsole;
 use Takemo101\Chubby\Hook\Hook;
 use Takemo101\Chubby\Http\SlimHttp;
 
@@ -132,12 +132,12 @@ class ServiceLocator
     /**
      * Get console application.
      *
-     * @return SymfonyConsoleAdapter
+     * @return SymfonyConsole
      */
-    public static function console(): SymfonyConsoleAdapter
+    public static function console(): SymfonyConsole
     {
-        /** @var SymfonyConsoleAdapter */
-        $console = self::container()->get(SymfonyConsoleAdapter::class);
+        /** @var SymfonyConsole */
+        $console = self::container()->get(SymfonyConsole::class);
 
         return $console;
     }

--- a/src/Test/HasConsoleTest.php
+++ b/src/Test/HasConsoleTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Takemo101\Chubby\ApplicationContainer;
 use RuntimeException;
 use Symfony\Component\Console\Tester\CommandTester;
-use Takemo101\Chubby\Console\SymfonyConsoleAdapter;
+use Takemo101\Chubby\Console\SymfonyConsole;
 
 /**
  * @method ApplicationContainer getContainer()
@@ -16,9 +16,9 @@ use Takemo101\Chubby\Console\SymfonyConsoleAdapter;
 trait HasConsoleTest
 {
     /**
-     * @var SymfonyConsoleAdapter
+     * @var SymfonyConsole
      */
-    private SymfonyConsoleAdapter $console;
+    private SymfonyConsole $console;
 
     /**
      * Set slim http adapter.
@@ -27,15 +27,15 @@ trait HasConsoleTest
      */
     protected function setUpConsole(): void
     {
-        $this->console = $this->getContainer()->get(SymfonyConsoleAdapter::class);
+        $this->console = $this->getContainer()->get(SymfonyConsole::class);
     }
 
     /**
      * Get symfony console adapter.
      *
-     * @return SymfonyConsoleAdapter
+     * @return SymfonyConsole
      */
-    protected function getConsole(): SymfonyConsoleAdapter
+    protected function getConsole(): SymfonyConsole
     {
         return isset($this->console)
             ? $this->console

--- a/src/Test/HasHttpTest.php
+++ b/src/Test/HasHttpTest.php
@@ -8,7 +8,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Takemo101\Chubby\ApplicationContainer;
-use Takemo101\Chubby\Http\SlimHttpAdapter;
+use Takemo101\Chubby\Http\SlimHttp;
 use RuntimeException;
 
 /**
@@ -19,9 +19,9 @@ use RuntimeException;
 trait HasHttpTest
 {
     /**
-     * @var SlimHttpAdapter
+     * @var SlimHttp
      */
-    private SlimHttpAdapter $http;
+    private SlimHttp $http;
 
     /**
      * Set slim http adapter.
@@ -30,15 +30,15 @@ trait HasHttpTest
      */
     protected function setUpHttp(): void
     {
-        $this->http = $this->getContainer()->get(SlimHttpAdapter::class);
+        $this->http = $this->getContainer()->get(SlimHttp::class);
     }
 
     /**
      * Get slim http adapter.
      *
-     * @return SlimHttpAdapter
+     * @return SlimHttp
      */
-    protected function getHttp(): SlimHttpAdapter
+    protected function getHttp(): SlimHttp
     {
         return isset($this->http)
             ? $this->http

--- a/src/helper.php
+++ b/src/helper.php
@@ -4,7 +4,7 @@ use Monolog\Level;
 use Psr\Log\LoggerInterface;
 use Takemo101\Chubby\Application;
 use Takemo101\Chubby\ApplicationContainer;
-use Takemo101\Chubby\Console\SymfonyConsoleAdapter;
+use Takemo101\Chubby\Console\SymfonyConsole;
 use Takemo101\Chubby\Hook\Hook;
 use Takemo101\Chubby\Http\SlimHttp;
 use Takemo101\Chubby\Support\ServiceLocator;
@@ -121,9 +121,9 @@ if (!function_exists('console')) {
     /**
      * Get console application.
      *
-     * @return SymfonyConsoleAdapter
+     * @return SymfonyConsole
      */
-    function console(): SymfonyConsoleAdapter
+    function console(): SymfonyConsole
     {
         return ServiceLocator::console();
     }

--- a/src/helper.php
+++ b/src/helper.php
@@ -6,7 +6,7 @@ use Takemo101\Chubby\Application;
 use Takemo101\Chubby\ApplicationContainer;
 use Takemo101\Chubby\Console\SymfonyConsoleAdapter;
 use Takemo101\Chubby\Hook\Hook;
-use Takemo101\Chubby\Http\SlimHttpAdapter;
+use Takemo101\Chubby\Http\SlimHttp;
 use Takemo101\Chubby\Support\ServiceLocator;
 
 if (!function_exists('container')) {
@@ -109,9 +109,9 @@ if (!function_exists('http')) {
     /**
      * Get http application.
      *
-     * @return SlimHttpAdapter
+     * @return SlimHttp
      */
-    function http(): SlimHttpAdapter
+    function http(): SlimHttp
     {
         return ServiceLocator::http();
     }

--- a/tests/Bootstrap/DefinitionHelperTest.php
+++ b/tests/Bootstrap/DefinitionHelperTest.php
@@ -23,7 +23,7 @@ describe(
             $defaultClass = 'DefaultClass';
             $hook = false;
 
-            $closure = DefinitionHelper::createReplaceableDefinition(
+            $closure = DefinitionHelper::createReplaceable(
                 $entry,
                 $configKey,
                 $defaultClass,
@@ -52,7 +52,7 @@ describe(
                 ->with($class)
                 ->andReturn($instance);
 
-            $closure = DefinitionHelper::createReplaceableDefinition(
+            $closure = DefinitionHelper::createReplaceable(
                 $entry,
                 $configKey,
                 $defaultClass,
@@ -94,7 +94,7 @@ describe(
                 ->with($entry, $instance)
                 ->andReturn($hookedInstance);
 
-            $closure = DefinitionHelper::createReplaceableDefinition(
+            $closure = DefinitionHelper::createReplaceable(
                 $entry,
                 $configKey,
                 $defaultClass,

--- a/tests/Console/SymfonyConsoleTest.php
+++ b/tests/Console/SymfonyConsoleTest.php
@@ -7,14 +7,14 @@ use Takemo101\Chubby\Application as ChubbyApplication;
 use Takemo101\Chubby\Console\Command\ClosureCommand;
 use Takemo101\Chubby\Console\CommandCollection;
 use Takemo101\Chubby\Console\CommandResolver;
-use Takemo101\Chubby\Console\SymfonyConsoleAdapter;
+use Takemo101\Chubby\Console\SymfonyConsole;
 use Tests\AppTestCase;
 
 describe(
     'console',
     function () {
         test(
-            'Create an instance of SymfonyConsoleAdapter and execute a command',
+            'Create an instance of SymfonyConsole and execute a command',
             function () {
                 /** @var AppTestCase $this */
 
@@ -22,7 +22,7 @@ describe(
 
                 $name = 'test';
 
-                $console = new SymfonyConsoleAdapter(
+                $console = new SymfonyConsole(
                     $app,
                     new CommandCollection(
                         ClosureCommand::from(fn () => ClosureCommand::SUCCESS)
@@ -57,7 +57,7 @@ describe(
         );
 
         test(
-            'Add commands to SymfonyConsoleAdapter and execute them',
+            'Add commands to SymfonyConsole and execute them',
             function (Command $command) {
                 /** @var AppTestCase $this */
 

--- a/tests/Http/SlimHttpTest.php
+++ b/tests/Http/SlimHttpTest.php
@@ -6,14 +6,14 @@ use Psr\Http\Message\ServerRequestInterface;
 use Slim\App;
 use Takemo101\Chubby\Http\Configurer\SlimConfigurer;
 use Takemo101\Chubby\Http\Renderer\JsonRenderer;
-use Takemo101\Chubby\Http\SlimHttpAdapter;
+use Takemo101\Chubby\Http\SlimHttp;
 use Tests\AppTestCase;
 
 describe(
     'http',
     function () {
         test(
-            'Create an instance of SlimHttpAdapter to handle requests',
+            'Create an instance of SlimHttp to handle requests',
             function () {
                 /** @var AppTestCase $this */
 
@@ -21,7 +21,7 @@ describe(
                 $app = $this->getContainer()->get(App::class);
                 $configurer = $this->getContainer()->get(SlimConfigurer::class);
 
-                $http = new SlimHttpAdapter($app, $configurer);
+                $http = new SlimHttp($app, $configurer);
 
                 $request = $this->createRequest('GET', '/');
 
@@ -34,7 +34,7 @@ describe(
         );
 
         test(
-            'Handle requests with SlimHttpAdapter',
+            'Handle requests with SlimHttp',
             function (string $method) {
                 /** @var AppTestCase $this */
 
@@ -64,7 +64,7 @@ describe(
         ]);
 
         test(
-            'Handle form requests with SlimHttpAdapter',
+            'Handle form requests with SlimHttp',
             function (string $method) {
                 /** @var AppTestCase $this */
 
@@ -102,7 +102,7 @@ describe(
         ]);
 
         test(
-            'Handle json requests with SlimHttpAdapter',
+            'Handle json requests with SlimHttp',
             function (string $method) {
                 /** @var AppTestCase $this */
 


### PR DESCRIPTION
## Overview

#### ``DomainRouter`` specification change

The ``DomainRouter`` was designed to add ``RequestHandler`` factories to domains, but has been changed to add ``RequestHandler`` instances with the ``mount`` method.
This change allows non-Slim applications to connect.

#### ``SlimHttpAdapter`` and ``SymfonyConsoleAdapter`` class name change
Changed ``SlimHttpAdapter`` and ``SymfonyConsoleAdapter`` to ``SlimHttp`` and ``SymfonyConsole`` because they were inappropriate names.


## Changes
<!-- List the changes made in this pull request. -->
1. change ``SymfonyConsoleAdapter`` class to ``SymfonyConsole``.
2. change ``SlimHttpAdapter`` class to ``SlimHttp``. 
3. add ``mount`` method to ``DomainRouter`` and remove ``route`` method.
4. change files under ``Takemo101\Chubby\Http``
