### PR TITLE
Fix dependency injection in ApplicationSummary

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -28,12 +28,14 @@ use Takemo101\Chubby\Bootstrap\Provider\ErrorProvider;
 use Takemo101\Chubby\Bootstrap\Provider\EventProvider;
 use Takemo101\Chubby\Bootstrap\Provider\HelperProvider;
 use Takemo101\Chubby\Bootstrap\Provider\LogProvider;
+use Takemo101\Chubby\Config\ConfigRepository;
 use Takemo101\Chubby\Container\InstantContainer;
 use Takemo101\Chubby\Filesystem\LocalFilesystem;
 use Takemo101\Chubby\Filesystem\Mime\MimeTypeGuesser;
 use Takemo101\Chubby\Filesystem\Mime\SymfonyMimeTypeGuesser;
 use Takemo101\Chubby\Filesystem\PathHelper;
 use Takemo101\Chubby\Filesystem\SymfonyLocalFilesystem;
+use Takemo101\Chubby\Support\ApplicationSummary;
 
 use function DI\get;
 
@@ -124,6 +126,25 @@ class Application implements ApplicationContainer
             [
                 Application::class => $this,
                 ApplicationPath::class => $this->path,
+                ApplicationSummary::class => function (
+                    ConfigRepository $config,
+                ) {
+                    /** @var string */
+                    $name = $config->get('app.name', self::Name);
+                    /** @var string */
+                    $env = $config->get('app.env', 'local');
+                    /** @var bool */
+                    $debug = $config->get('app.debug', true);
+                    /** @var bool */
+                    $builtInServer = $config->get('app.built_in_server', false);
+
+                    return new ApplicationSummary(
+                        name: $name,
+                        env: $env,
+                        debug: $debug,
+                        builtInServer: $builtInServer,
+                    );
+                },
                 ApplicationContainer::class => get(Application::class),
                 ContainerInterface::class => get(Application::class),
                 InvokerInterface::class => get(Application::class),

--- a/src/Support/ApplicationSummary.php
+++ b/src/Support/ApplicationSummary.php
@@ -2,7 +2,6 @@
 
 namespace Takemo101\Chubby\Support;
 
-use DI\Attribute\Inject;
 use Takemo101\Chubby\Application;
 
 /**
@@ -24,13 +23,9 @@ readonly class ApplicationSummary
      * @param boolean $builtInServer
      */
     public function __construct(
-        #[Inject('config.app.name')]
         public string $name = Application::Name,
-        #[Inject('config.app.env')]
         string $env = 'local',
-        #[Inject('config.app.debug')]
         public bool $debug = true,
-        #[Inject('config.app.built_in_server')]
         public bool $builtInServer = false,
     ) {
         $this->env = strtolower($env);


### PR DESCRIPTION
## Overview
Fixed dependency injection setting for ``ApplicationSummary`` in ``Application`` class, since injecting dependency values into ``ApplicationSummary`` using ``Inject`` in PHP-DI does not allow to set default values
