### PR TITLE
Modified AttachmentRenderer to allow for additional processing after the response is sent.

### DIFF
--- a/.github/workflows/formats.yml
+++ b/.github/workflows/formats.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.2]
+        php: [8.2, 8.3]
 
     name: Formats P${{ matrix.php }} - ${{ matrix.os }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        php: [8.2]
+        php: [8.2, 8.3]
 
     name: Tests P${{ matrix.php }} - ${{ matrix.os }}
 

--- a/src/Console/Command/ClosureCommand.php
+++ b/src/Console/Command/ClosureCommand.php
@@ -50,7 +50,7 @@ class ClosureCommand extends AbstractCommand implements ContainerInjectable
      */
     protected function getContainer(): ApplicationContainer
     {
-        return $this->container ?? throw new LogicException('container is not set!');
+        return $this->container ?? throw new LogicException('ApplicationContainer is not set!');
     }
 
     /**

--- a/src/Http/Renderer/AbstractStreamRenderer.php
+++ b/src/Http/Renderer/AbstractStreamRenderer.php
@@ -8,6 +8,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use SplFileInfo;
+use LogicException;
 use RuntimeException;
 use DateTime;
 use DateTimeZone;
@@ -114,6 +115,16 @@ abstract class AbstractStreamRenderer implements ResponseRenderer, ContainerInje
     }
 
     /**
+     * Get status code to be rendered.
+     *
+     * @return int
+     */
+    public function getStatus(): int
+    {
+        return $this->status;
+    }
+
+    /**
      * Set headers to be rendered.
      *
      * @param array<string,string> $headers
@@ -124,6 +135,16 @@ abstract class AbstractStreamRenderer implements ResponseRenderer, ContainerInje
         $this->headers = $headers;
 
         return $this;
+    }
+
+    /**
+     * Get headers to be rendered.
+     *
+     * @return array<string,string>
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
     }
 
     /**
@@ -216,7 +237,7 @@ abstract class AbstractStreamRenderer implements ResponseRenderer, ContainerInje
      */
     protected function getContainer(): ApplicationContainer
     {
-        return $this->container ?? throw new RuntimeException('ApplicationContainer is not set.');
+        return $this->container ?? throw new LogicException('ApplicationContainer is not set.');
     }
 
     /**
@@ -243,7 +264,7 @@ abstract class AbstractStreamRenderer implements ResponseRenderer, ContainerInje
         ServerRequestInterface $request,
         ResponseInterface $response,
     ): ResponseInterface {
-        foreach ($this->headers as $key => $value) {
+        foreach ($this->getHeaders() as $key => $value) {
             $response = $response->withHeader($key, $value);
         }
 
@@ -251,7 +272,7 @@ abstract class AbstractStreamRenderer implements ResponseRenderer, ContainerInje
 
         $response = $this->configureResponse(
             $response
-                ->withStatus($this->status)
+                ->withStatus($this->getStatus())
                 ->withHeader('Content-Type', $this->getContentType())
                 ->withHeader('Content-Length', (string)$stream->getSize())
         );

--- a/src/Http/Renderer/RouteRedirectRenderer.php
+++ b/src/Http/Renderer/RouteRedirectRenderer.php
@@ -120,7 +120,7 @@ class RouteRedirectRenderer implements ResponseRenderer, ContainerInjectable
      */
     protected function getContainer(): ApplicationContainer
     {
-        return $this->container ?? throw new LogicException('container is not set!');
+        return $this->container ?? throw new LogicException('ApplicationContainer is not set!');
     }
 
     /**

--- a/src/Test/HasConsoleTest.php
+++ b/src/Test/HasConsoleTest.php
@@ -3,10 +3,10 @@
 namespace Takemo101\Chubby\Test;
 
 use PHPUnit\Framework\TestCase;
-use Takemo101\Chubby\ApplicationContainer;
-use RuntimeException;
 use Symfony\Component\Console\Tester\CommandTester;
+use Takemo101\Chubby\ApplicationContainer;
 use Takemo101\Chubby\Console\SymfonyConsole;
+use LogicException;
 
 /**
  * @method ApplicationContainer getContainer()
@@ -39,7 +39,7 @@ trait HasConsoleTest
     {
         return isset($this->console)
             ? $this->console
-            : throw new RuntimeException('Console is not set.');
+            : throw new LogicException('Console is not set.');
     }
 
     /**

--- a/src/Test/HasContainerTest.php
+++ b/src/Test/HasContainerTest.php
@@ -4,8 +4,8 @@ namespace Takemo101\Chubby\Test;
 
 use PHPUnit\Framework\TestCase;
 use Takemo101\Chubby\ApplicationContainer;
-use RuntimeException;
 use Takemo101\Chubby\Application;
+use LogicException;
 
 /**
  * @mixin TestCase
@@ -41,6 +41,6 @@ trait HasContainerTest
     {
         return isset($this->container)
             ? $this->container
-            : throw new RuntimeException('Container is not set.');
+            : throw new LogicException('Container is not set.');
     }
 }

--- a/src/Test/HasHttpTest.php
+++ b/src/Test/HasHttpTest.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Takemo101\Chubby\ApplicationContainer;
 use Takemo101\Chubby\Http\SlimHttp;
-use RuntimeException;
+use LogicException;
 
 /**
  * @method ApplicationContainer getContainer()
@@ -42,7 +42,7 @@ trait HasHttpTest
     {
         return isset($this->http)
             ? $this->http
-            : throw new RuntimeException('Http is not set.');
+            : throw new LogicException('Http is not set.');
     }
 
     /**

--- a/tests/Http/Renderer/AttatchmentRendererTest.php
+++ b/tests/Http/Renderer/AttatchmentRendererTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use Fig\Http\Message\StatusCodeInterface;
+use Psr\Http\Message\ResponseInterface;
+use Takemo101\Chubby\Http\Renderer\AttatchmentRenderer;
+use Tests\AppTestCase;
+
+describe(
+    'AttatchmentRenderer',
+    function () {
+
+        it('should configure the response with the correct Content-Disposition header', function () {
+            /** @var AppTestCase $this */
+
+            $data = 'test data';
+            $name = 'test.txt';
+            $mime = 'text/plain';
+            $status = StatusCodeInterface::STATUS_OK;
+            $headers = [];
+
+            $renderer = new AttatchmentRenderer($data, $name, $mime, null, $status, $headers);
+            $renderer->setContainer($this->getContainer());
+
+            $response = $renderer->render(
+                $this->createRequest(),
+                $this->createResponse(),
+            );
+
+            expect($response)->toBeInstanceOf(ResponseInterface::class);
+            expect($response->getHeaderLine('Content-Disposition'))->toBe('attachment; filename="test.txt"');
+        });
+
+        it('should set the default file name if no name is provided', function () {
+            /** @var AppTestCase $this */
+
+            $data = 'test data';
+            $mime = 'text/plain';
+            $status = StatusCodeInterface::STATUS_OK;
+            $headers = [];
+
+            $renderer = new AttatchmentRenderer($data, '', $mime, null, $status, $headers);
+            $renderer->setContainer($this->getContainer());
+
+            $response = $renderer->render(
+                $this->createRequest(),
+                $this->createResponse(),
+            );
+
+            expect($response)->toBeInstanceOf(ResponseInterface::class);
+            expect($response->getHeaderLine('Content-Disposition'))->toBe('attachment; filename="file"');
+        });
+
+        it('should call the finally callback when the renderer is destroyed', function () {
+            $data = 'test data';
+            $mime = 'text/plain';
+            $status = StatusCodeInterface::STATUS_OK;
+            $headers = [];
+            $finallyCalled = false;
+
+            $finally = function ($renderer) use (&$finallyCalled) {
+                $finallyCalled = true;
+            };
+
+            $renderer = new AttatchmentRenderer($data, '', $mime, $finally, $status, $headers);
+
+            unset($renderer);
+
+            expect($finallyCalled)->toBeTrue();
+        });
+
+        it('should create a renderer instance from a file path', function () {
+            $path = '/path/to/file.txt';
+            $name = 'file.txt';
+            $mime = 'text/plain';
+            $status = StatusCodeInterface::STATUS_OK;
+            $headers = [];
+
+            $renderer = AttatchmentRenderer::fromPath($path, $name, $mime, null, $status, $headers);
+
+            expect($renderer)->toBeInstanceOf(AttatchmentRenderer::class);
+            expect($renderer->getData())->toBeInstanceOf(SplFileInfo::class);
+            expect($renderer->getName())->toBe('file.txt');
+            expect($renderer->getMimeType())->toBe('text/plain');
+            expect($renderer->getStatus())->toBe(StatusCodeInterface::STATUS_OK);
+            expect($renderer->getHeaders())->toBe($headers);
+        });
+    }
+)->group('AttatchmentRenderer', 'renderer');

--- a/tests/Http/Renderer/RouteRedirectRendererTest.php
+++ b/tests/Http/Renderer/RouteRedirectRendererTest.php
@@ -40,4 +40,4 @@ it(
 
         expect($result)->toBe($response);
     }
-)->group('route-redirect-renderer', 'renderer');
+)->group('RouteRedirectRenderer', 'renderer');

--- a/tests/Http/ResponseRendererTest.php
+++ b/tests/Http/ResponseRendererTest.php
@@ -3,7 +3,6 @@
 use Fig\Http\Message\StatusCodeInterface;
 use Takemo101\Chubby\Contract\Arrayable;
 use Takemo101\Chubby\Contract\Renderable;
-use Takemo101\Chubby\Http\Renderer\AttatchmentRenderer;
 use Takemo101\Chubby\Http\Renderer\HtmlRenderer;
 use Takemo101\Chubby\Http\Renderer\JsonRenderer;
 use Takemo101\Chubby\Http\Renderer\RedirectRenderer;


### PR DESCRIPTION
## Overview
Modified ``AttachmentRenderer`` to allow for additional processing after the response is sent.

## Changes
1. post-processing added after sending response to ``AttachementRenderer``.
2. changed some ``RuntimeException`` exceptions to ``LogicException``.
3. added php8.3 to github actions workflow
