### PR TITLE
Refactor dotenv file read settings

### DIFF
--- a/.env.testing
+++ b/.env.testing
@@ -1,0 +1,12 @@
+### for docker ###
+UID=1000
+
+### for app ###
+APP_NAME=Chubby
+APP_ENV=testing
+APP_DEBUG=true
+
+### for server ###
+# SERVER_PORT=8080
+# SERVER_HOST=localhost
+# SERVER_SCRIPT=/index.php

--- a/src/Application.php
+++ b/src/Application.php
@@ -36,6 +36,7 @@ use Takemo101\Chubby\Filesystem\Mime\SymfonyMimeTypeGuesser;
 use Takemo101\Chubby\Filesystem\PathHelper;
 use Takemo101\Chubby\Filesystem\SymfonyLocalFilesystem;
 use Takemo101\Chubby\Support\ApplicationSummary;
+use Takemo101\Chubby\Support\ExternalEnvironmentAccessor;
 
 use function DI\get;
 
@@ -96,6 +97,7 @@ class Application implements ApplicationContainer
         $mimeTypes = MimeTypes::getDefault();
         $mimeTypeGuesser = new SymfonyMimeTypeGuesser($mimeTypes);
         $filesystem = new SymfonyLocalFilesystem($mimeTypeGuesser);
+        $envAccessor = new ExternalEnvironmentAccessor();
 
         $this->instantContainer
             ->add($this)
@@ -109,15 +111,15 @@ class Application implements ApplicationContainer
                 LocalFilesystem::class,
             )
             ->add($this->path)
-            ->add($pathHelper);
+            ->add($pathHelper)
+            ->add($envAccessor);
 
         // Add a provider that satisfies the dependencies required to run the application
         $bootstrap->addProvider(
             new BootStartProvider(),
             new EnvironmentProvider(
-                paths: [
-                    $this->path->getBasePath(),
-                ],
+                path: $this->path,
+                envAccessor: $envAccessor,
             ),
             new ErrorProvider(),
             new EventProvider(),

--- a/src/Application.php
+++ b/src/Application.php
@@ -114,7 +114,11 @@ class Application implements ApplicationContainer
         // Add a provider that satisfies the dependencies required to run the application
         $bootstrap->addProvider(
             new BootStartProvider(),
-            new EnvironmentProvider($this->path),
+            new EnvironmentProvider(
+                paths: [
+                    $this->path->getBasePath(),
+                ],
+            ),
             new ErrorProvider(),
             new EventProvider(),
             new ConfigProvider(),

--- a/src/ApplicationOption.php
+++ b/src/ApplicationOption.php
@@ -22,9 +22,6 @@ readonly class ApplicationOption
     /** @var string */
     public const DefaultStoragePath = '/storage';
 
-    /** @var string[] */
-    public const DefaultDotenvNames = ['.env'];
-
     /**
      * constructor
      *
@@ -32,7 +29,6 @@ readonly class ApplicationOption
      * @param string $configPath
      * @param string $settingPath
      * @param string $storagePath
-     * @param string[] $dotenvNames
      * @param ContainerBuilder<Container> $builder
      * @param Bootstrap $bootstrap
      */
@@ -41,7 +37,6 @@ readonly class ApplicationOption
         public string $configPath,
         public string $settingPath,
         public string $storagePath,
-        public array $dotenvNames,
         public ContainerBuilder $builder,
         public Bootstrap $bootstrap,
     ) {
@@ -66,7 +61,6 @@ readonly class ApplicationOption
             configPath: $this->configPath,
             settingPath: $this->settingPath,
             storagePath: $this->storagePath,
-            dotenvNames: $this->dotenvNames,
         );
     }
 
@@ -77,7 +71,6 @@ readonly class ApplicationOption
      * @param string|null $configPath
      * @param string|null $settingPath
      * @param string|null $storagePath
-     * @param string[]|null $dotenvNames
      * @param ContainerBuilder<Container>|null $builder
      * @param Bootstrap|null $bootstrap
      * @return self
@@ -87,7 +80,6 @@ readonly class ApplicationOption
         ?string $configPath = null,
         ?string $settingPath = null,
         ?string $storagePath = null,
-        ?array $dotenvNames = null,
         ?ContainerBuilder $builder = null,
         ?Bootstrap $bootstrap = null,
     ): self {
@@ -98,7 +90,6 @@ readonly class ApplicationOption
             configPath: empty($configPath) ? self::DefaultConfigPath : $configPath,
             settingPath: empty($settingPath) ? self::DefaultSettingPath : $settingPath,
             storagePath: empty($storagePath) ? self::DefaultStoragePath : $storagePath,
-            dotenvNames: empty($dotenvNames) ? self::DefaultDotenvNames : $dotenvNames,
             builder: $builder ?? (new ContainerBuilder())
                 ->useAttributes(true),
             bootstrap: $bootstrap ?? new Bootstrap(),

--- a/src/Bootstrap/Provider/BootStartProvider.php
+++ b/src/Bootstrap/Provider/BootStartProvider.php
@@ -65,21 +65,25 @@ class BootStartProvider implements Provider
      * Add definition.
      *
      * @param string|mixed[]|DefinitionSource $definition
-     * @return void
+     * @return self
      */
-    public function addDefinition(string|array|DefinitionSource $definition): void
+    public function addDefinition(string|array|DefinitionSource $definition): self
     {
         $this->definitions[] = $definition;
+
+        return $this;
     }
 
     /**
      * Add booting.
      *
      * @param callable(ApplicationContainer):void $booting
-     * @return void
+     * @return self
      */
-    public function addBoot(callable $booting): void
+    public function addBoot(callable $booting): self
     {
         $this->booting[] = $booting;
+
+        return $this;
     }
 }

--- a/src/Bootstrap/Provider/ConfigProvider.php
+++ b/src/Bootstrap/Provider/ConfigProvider.php
@@ -93,10 +93,12 @@ class ConfigProvider implements Provider
      * Set config repository.
      *
      * @param ConfigRepository $repository
-     * @return void
+     * @return self
      */
-    public function setConfigRepository(ConfigRepository $repository): void
+    public function setConfigRepository(ConfigRepository $repository): self
     {
         $this->repository = $repository;
+
+        return $this;
     }
 }

--- a/src/Bootstrap/Provider/DependencyProvider.php
+++ b/src/Bootstrap/Provider/DependencyProvider.php
@@ -35,8 +35,8 @@ class DependencyProvider implements Provider
      * @param LocalFilesystem $filesystem
      */
     public function __construct(
-        private ApplicationPath $path,
-        private LocalFilesystem $filesystem,
+        private readonly ApplicationPath $path,
+        private readonly LocalFilesystem $filesystem,
     ) {
         //
     }

--- a/src/Bootstrap/Provider/DependencyProvider.php
+++ b/src/Bootstrap/Provider/DependencyProvider.php
@@ -112,10 +112,12 @@ class DependencyProvider implements Provider
      * Set dependency definitions paths.
      *
      * @param string ...$paths
-     * @return void
+     * @return self
      */
-    public function setDependencyPath(string ...$paths): void
+    public function setDependencyPath(string ...$paths): self
     {
         $this->dependencyPaths = $paths;
+
+        return $this;
     }
 }

--- a/src/Bootstrap/Provider/EnvironmentProvider.php
+++ b/src/Bootstrap/Provider/EnvironmentProvider.php
@@ -11,7 +11,6 @@ use Dotenv\Repository\RepositoryInterface;
 use Psr\Log\LoggerInterface;
 use Takemo101\Chubby\ApplicationContainer;
 use Takemo101\Chubby\Bootstrap\Definitions;
-use Takemo101\Chubby\Support\ApplicationPath;
 use Takemo101\Chubby\Support\Environment;
 
 /**
@@ -30,9 +29,11 @@ class EnvironmentProvider implements Provider
     public const EnvPrependKey = 'env';
 
     /**
-     * @var string[]
+     * @var string[] Default dotenv file names.
      */
-    private array $envPaths;
+    public const DefaultEnvNames = [
+        '.env',
+    ];
 
     /**
      * @var boolean Should throw exception on missing dotenv.
@@ -40,14 +41,27 @@ class EnvironmentProvider implements Provider
     private $shouldThrowsExceptionOnMissingDotenv = false;
 
     /**
+     * @var string[] Dotenv directory paths.
+     */
+    private array $paths;
+
+    /**
+     * @var string[] Dotenv file names.
+     */
+    private array $names;
+
+    /**
      * constructor
      *
-     * @param ApplicationPath $path
+     * @param string[] $paths Dotenv directory paths.
+     * @param string[] $names Dotenv file names.
      */
     public function __construct(
-        private ApplicationPath $path,
+        array $paths,
+        array $names = self::DefaultEnvNames,
     ) {
-        $this->envPaths = [$path->getBasePath()];
+        $this->setDotenvPath(...$paths);
+        $this->setDotenvName(...$names);
     }
 
     /**
@@ -68,8 +82,8 @@ class EnvironmentProvider implements Provider
                         ->immutable()
                         ->make();
 
-                    $paths = $this->envPaths;
-                    $names = $this->path->getDotenvNames();
+                    $paths = $this->paths;
+                    $names = $this->names;
 
                     try {
                         Dotenv::create(
@@ -122,17 +136,39 @@ class EnvironmentProvider implements Provider
     }
 
     /**
-     * Add env path.
+     * Set dotenv directory path.
      *
-     * @param string $path
-     * @return void
+     * @param string ...$paths
+     * @return self
      */
-    public function addEnvPath(string $path): void
+    public function setDotenvPath(string ...$paths): self
     {
-        $this->envPaths = array_unique([
-            ...$this->envPaths,
-            $path,
-        ]);
+        assert(
+            !empty($paths),
+            'EnvironmentProvider requires at least one path.'
+        );
+
+        $this->paths = $paths;
+
+        return $this;
+    }
+
+    /**
+     * Set dotenv file name.
+     *
+     * @param string ...$names Dotenv file names.
+     * @return self
+     */
+    public function setDotenvName(string ...$names): self
+    {
+        assert(
+            !empty($names),
+            'EnvironmentProvider requires at least one name.'
+        );
+
+        $this->names = $names;
+
+        return $this;
     }
 
     /**

--- a/src/Bootstrap/Provider/FunctionProvider.php
+++ b/src/Bootstrap/Provider/FunctionProvider.php
@@ -34,8 +34,8 @@ class FunctionProvider implements Provider
      * @param LocalFilesystem $filesystem
      */
     public function __construct(
-        private ApplicationPath $path,
-        private LocalFilesystem $filesystem,
+        private readonly ApplicationPath $path,
+        private readonly LocalFilesystem $filesystem,
     ) {
         //
     }
@@ -92,10 +92,12 @@ class FunctionProvider implements Provider
      * Set function paths.
      *
      * @param string ...$paths
-     * @return void
+     * @return self
      */
-    public function setFunctionPath(string ...$paths): void
+    public function setFunctionPath(string ...$paths): self
     {
         $this->functionPaths = $paths;
+
+        return $this;
     }
 }

--- a/src/Support/ApplicationPath.php
+++ b/src/Support/ApplicationPath.php
@@ -18,14 +18,12 @@ readonly class ApplicationPath
      * @param string $settingPath setting directory path
      * @param string $configPath config directory path
      * @param string $storagePath storage directory path
-     * @param string[] $dotenvNames dotenv file names
      */
     public function __construct(
         public string $basePath,
         public string $settingPath = '/setting',
         public string $configPath = '/config',
         public string $storagePath = '/storage',
-        public array $dotenvNames = ['.env'],
     ) {
         $this->helper = new PathHelper();
     }
@@ -81,15 +79,5 @@ readonly class ApplicationPath
             $this->storagePath,
             ...$paths
         );
-    }
-
-    /**
-     * Get dotenv file names
-     *
-     * @return string[]
-     */
-    public function getDotenvNames(): array
-    {
-        return $this->dotenvNames;
     }
 }

--- a/src/Support/Environment.php
+++ b/src/Support/Environment.php
@@ -13,9 +13,11 @@ class Environment
      * constructor
      *
      * @param RepositoryInterface $repository
+     * @param EnvironmentStringParser $parser
      */
     public function __construct(
         private readonly RepositoryInterface $repository,
+        private readonly EnvironmentStringParser $parser = new EnvironmentStringParser(),
     ) {
         //
     }
@@ -34,19 +36,8 @@ class Environment
             strtoupper($key),
         );
 
-        if (is_null($value)) {
-            return $default;
-        }
-
-        $lower = strtolower($value);
-
-        return match ($lower) {
-            'true', '(true)' => true,
-            'false', '(false)' => false,
-            'empty', '(empty)' => '',
-            'null', '(null)' => null,
-            preg_match('/\A([\'"])(.*)\1\z/', $value, $matches) !== false => $matches[2], /* @phpstan-ignore-line */
-            default => $value,
-        };
+        return $value === null
+            ? $default
+            : $this->parser->parse($value);
     }
 }

--- a/src/Support/EnvironmentStringParser.php
+++ b/src/Support/EnvironmentStringParser.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Takemo101\Chubby\Support;
+
+/**
+ * Parse environment string to primitive.
+ */
+class EnvironmentStringParser
+{
+    /**
+     * Parse environment string to primitive.
+     *
+     * @param string $value
+     * @return mixed
+     */
+    public function parse(string $value): mixed
+    {
+        $lower = strtolower($value);
+
+        return match ($lower) {
+            'true', '(true)' => true,
+            'false', '(false)' => false,
+            'empty', '(empty)' => '',
+            'null', '(null)' => null,
+            default => preg_match('/\A([\'"])(.*)\1\z/', $value, $matches)
+                ? $matches[2]
+                : $value,
+        };
+    }
+}

--- a/src/Support/ExternalEnvironmentAccessor.php
+++ b/src/Support/ExternalEnvironmentAccessor.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Takemo101\Chubby\Support;
+
+/**
+ * Get environment variable from external source.
+ */
+class ExternalEnvironmentAccessor
+{
+    /**
+     * constructor
+     *
+     * @param EnvironmentStringParser $parser
+     */
+    public function __construct(
+        private readonly EnvironmentStringParser $parser = new EnvironmentStringParser(),
+    ) {
+        //
+    }
+
+    /**
+     * Get environment variable.
+     *
+     * @param string $key
+     * @param mixed $default
+     * @return mixed
+     */
+    public function get(string $key, mixed $default = null): mixed
+    {
+        /** @var string|false */
+        $value = getenv($key);
+
+        return $value === false
+            ? $default
+            : $this->parser->parse($value);
+    }
+}

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -25,14 +25,12 @@ describe(
                 $configDirectory = '/config';
                 $settingDirectory = '/setting';
                 $storageDirectory = '/storage';
-                $dotenvNames = ['.env'];
 
                 $option = ApplicationOption::from(
                     basePath: $basePath,
                     configPath: $configDirectory,
                     settingPath: $settingDirectory,
                     storagePath: $storageDirectory,
-                    dotenvNames: $dotenvNames,
                 );
 
                 $realBasePath = realpath($basePath);
@@ -43,7 +41,6 @@ describe(
                 expect($path->getConfigPath())->toEqual($realBasePath . $configDirectory);
                 expect($path->getSettingPath())->toEqual($realBasePath . $settingDirectory);
                 expect($path->getStoragePath())->toEqual($realBasePath . $storageDirectory);
-                expect($path->getDotenvNames())->toEqual($dotenvNames);
             },
         )->skipOnWindows();
 

--- a/tests/Support/EnvironmentStringParserTest.php
+++ b/tests/Support/EnvironmentStringParserTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use Takemo101\Chubby\Support\EnvironmentStringParser;
+
+beforeEach(function () {
+    $this->parser = new EnvironmentStringParser();
+});
+
+describe(
+    'EnvironmentStringParser',
+    function () {
+        it('should parse "true" string to true', function () {
+            $result = $this->parser->parse('true');
+            expect($result)->toBeTrue();
+        });
+
+        it('should parse "(true)" string to true', function () {
+            $result = $this->parser->parse('(true)');
+            expect($result)->toBeTrue();
+        });
+
+        it('should parse "false" string to false', function () {
+            $result = $this->parser->parse('false');
+            expect($result)->toBeFalse();
+        });
+
+        it('should parse "(false)" string to false', function () {
+            $result = $this->parser->parse('(false)');
+            expect($result)->toBeFalse();
+        });
+
+        it('should parse "empty" string to empty string', function () {
+            $result = $this->parser->parse('empty');
+            expect($result)->toBe('');
+        });
+
+        it('should parse "(empty)" string to empty string', function () {
+            $result = $this->parser->parse('(empty)');
+            expect($result)->toBe('');
+        });
+
+        it('should parse "null" string to null', function () {
+            $result = $this->parser->parse('null');
+            expect($result)->toBeNull();
+        });
+
+        it('should parse "(null)" string to null', function () {
+            $result = $this->parser->parse('(null)');
+            expect($result)->toBeNull();
+        });
+
+        it('should parse quoted string to unquoted string', function () {
+            $result = $this->parser->parse('"quoted"');
+
+            expect($result)->toBe('quoted');
+        });
+
+        it('should parse default value', function () {
+            $result = $this->parser->parse('default');
+            expect($result)->toBe('default');
+        });
+    }
+)->group('EnvironmentStringParser', 'support');


### PR DESCRIPTION
## Overview
Refactored dotenv file loading settings in ``EnvironmentProvider``.
Previously, the dotenv file name was specified in ``ApplicationOption``, but with this modification, it can now be specified in ``EnvironmentProvider``.

Configuration Example
```php
<?php

$app->getProvider(EnvironmentProvider::class)->setDotenvNames(
    '.env',
    '.env.local',
);

$app->run();
````

When an application's environment is set externally, ``.env`` is retrieved according to the environment setting.

## Changes
1. Refactoring of the ``EnvironmentProvider`` class.
2. removed ``dotenvNames`` property from ``ApplicationOption`` and ``ApplicationPath`` classes
3. refactoring of other ``Provider`` classes
4. Separated the environment variable value conversion process into the ``EnvironmentStringParser`` class.
5. Added ``ExternalEnvironmentAccessor`` class for retrieving external environment variable setting values
