### PR TITLE
Fix order of adding middleware to Slim

### DIFF
--- a/config/event.php
+++ b/config/event.php
@@ -2,18 +2,10 @@
 
 // Event configuration
 
-use Takemo101\Chubby\Event\EventDispatcher;
-use Takemo101\Chubby\Event\EventListenerProvider;
-
 return [
-    // EventDispatcherInterface implementation class name
-    'dispatcher' => EventDispatcher::class,
-
-    // ListenerProviderInterface implementation class name
-    'provider' => EventListenerProvider::class,
 
     // Event listing class name array
-    'listen' => [
+    'listeners' => [
         // class-string<object&callable>
     ]
 ];

--- a/config/slim.php
+++ b/config/slim.php
@@ -2,26 +2,13 @@
 
 // Slim framework configuration
 
-use Takemo101\Chubby\Http\Configurer\DefaultSlimConfigurer;
-use Takemo101\Chubby\Http\ErrorHandler\ErrorHandler;
-use Takemo101\Chubby\Http\Factory\DefaultSlimFactory;
-
 return [
 
     // Base path
     'base_path' => env('BASE_PATH'),
 
-    // Specify a class that implements Slimfactory, a factor class that generates Slim
-    'factory' => DefaultSlimFactory::class,
-
-    // Specify a class that implements Slimconfigurer to perform setting processing before executing Slim
-    'configurer' => DefaultSlimConfigurer::class,
-
     // Error output settings
     'error' => [
-
-        // Slim error handling specified classes that implement Error HandlerInterface
-        'handler' => ErrorHandler::class,
 
         // ErrorMiddleware error display setting
         'setting' => [

--- a/src/Bootstrap/Provider/EventProvider.php
+++ b/src/Bootstrap/Provider/EventProvider.php
@@ -38,7 +38,7 @@ class EventProvider implements Provider
                     Hook $hook,
                 ) {
                     /** @var class-string[] */
-                    $listen = $config->get('event.listen', []);
+                    $listen = $config->get('event.listeners', []);
 
                     $register = EventRegister::fromArray($listen);
 

--- a/src/Bootstrap/Provider/HttpProvider.php
+++ b/src/Bootstrap/Provider/HttpProvider.php
@@ -35,7 +35,6 @@ use Takemo101\Chubby\Http\ErrorHandler\ErrorHandler;
 use Takemo101\Chubby\Http\ErrorHandler\ErrorResponseRenders;
 use Takemo101\Chubby\Http\GlobalMiddlewareCollection;
 use Takemo101\Chubby\Http\Listener\ApplicationUriReplace;
-use Takemo101\Chubby\Http\Middleware\StartContext;
 use Takemo101\Chubby\Http\ResponseTransformer\ArrayableTransformer;
 use Takemo101\Chubby\Http\ResponseTransformer\InjectableFilter;
 use Takemo101\Chubby\Http\ResponseTransformer\RenderableTransformer;
@@ -81,8 +80,6 @@ class HttpProvider implements Provider
                     Hook $hook,
                 ): Slim {
                     $slim = $factory->create();
-
-                    $slim->add(StartContext::class);
 
                     $hook->doTyped($slim, true);
                     $hook->do(RouteCollectorProxyInterface::class, $slim, true);

--- a/src/Http/Configurer/DefaultSlimConfigurer.php
+++ b/src/Http/Configurer/DefaultSlimConfigurer.php
@@ -6,7 +6,6 @@ use DI\Attribute\Inject;
 use Slim\App as Slim;
 use Slim\Middleware\BodyParsingMiddleware;
 use Slim\Middleware\ErrorMiddleware;
-use Takemo101\Chubby\Http\GlobalMiddlewareCollection;
 
 class DefaultSlimConfigurer implements SlimConfigurer
 {
@@ -18,11 +17,9 @@ class DefaultSlimConfigurer implements SlimConfigurer
     /**
      * constructor
      *
-     * @param GlobalMiddlewareCollection $middlewares
      * @param string|null $basePath
      */
     public function __construct(
-        private GlobalMiddlewareCollection $middlewares,
         #[Inject('config.slim.base_path')]
         ?string $basePath = null,
     ) {
@@ -44,10 +41,6 @@ class DefaultSlimConfigurer implements SlimConfigurer
         $slim->addRoutingMiddleware();
         $slim->add(BodyParsingMiddleware::class);
         $slim->add(ErrorMiddleware::class);
-
-        foreach ($this->middlewares->classes() as $middleware) {
-            $slim->add($middleware);
-        }
 
         return $slim;
     }

--- a/src/Http/Factory/DefaultSlimFactory.php
+++ b/src/Http/Factory/DefaultSlimFactory.php
@@ -6,6 +6,8 @@ use Psr\Container\ContainerInterface;
 use Slim\App as Slim;
 use Slim\Factory\AppFactory;
 use Slim\Interfaces\InvocationStrategyInterface;
+use Takemo101\Chubby\Http\GlobalMiddlewareCollection;
+use Takemo101\Chubby\Http\Middleware\StartContext;
 
 class DefaultSlimFactory implements SlimFactory
 {
@@ -14,10 +16,12 @@ class DefaultSlimFactory implements SlimFactory
      *
      * @param ContainerInterface $container
      * @param InvocationStrategyInterface $invocationStrategy
+     * @param GlobalMiddlewareCollection $middlewares
      */
     public function __construct(
-        private ContainerInterface $container,
-        private InvocationStrategyInterface $invocationStrategy,
+        private readonly ContainerInterface $container,
+        private readonly InvocationStrategyInterface $invocationStrategy,
+        private readonly GlobalMiddlewareCollection $middlewares,
     ) {
         //
     }
@@ -33,6 +37,12 @@ class DefaultSlimFactory implements SlimFactory
 
         $app->getRouteCollector()
             ->setDefaultInvocationStrategy($this->invocationStrategy);
+
+        foreach ($this->middlewares->classes() as $middleware) {
+            $app->add($middleware);
+        }
+
+        $app->add(StartContext::class);
 
         return $app;
     }


### PR DESCRIPTION
## Overview
Fixed the order in which middleware was added to Slim, as the middleware was running in the reverse order in which it was added and the ``StartContext`` middleware was not running at the beginning.
Also, we removed the dependency class settings in ``slim.php`` and other config files.

## Changes
1. Organize configuration file settings.
2. Fixed the configuration order of Slim middleware.
3. Added ``DefaultLoggerFactory`` dependency settings.
