### PR TITLE
Added the ability to set dependencies for major interfaces in the config file.

### DIFF
--- a/config/event.php
+++ b/config/event.php
@@ -7,5 +7,11 @@ return [
     // Event listing class name array
     'listeners' => [
         // class-string<object&callable>
-    ]
+    ],
+
+    // This configuration is used to modify the dependencies for Event.
+    'dependencies' => [
+        // Symfony\Contracts\EventDispatcher\EventDispatcherInterface::class  => ImplEventDispatcher::class,
+        // Takemo101\Chubby\Event\ListenerProvider::class => EventListenerProvider::class,
+    ],
 ];

--- a/config/slim.php
+++ b/config/slim.php
@@ -25,4 +25,11 @@ return [
     'middlewares' => [
         // class-string<MiddlewareInterface>
     ],
+
+    // This configuration is used to modify the dependencies for Slim.
+    'dependencies' => [
+        // Takemo101\Chubby\Http\Factory\SlimFactory::class => ImplSlimFactory::class,
+        // Takemo101\Chubby\Http\Configurer\SlimConfigurer::class => ImplSlimConfigurer::class,
+        // Slim\Interfaces\ErrorHandlerInterface::class => ImplErrorHandler::class,
+    ],
 ];

--- a/src/Bootstrap/Provider/EventProvider.php
+++ b/src/Bootstrap/Provider/EventProvider.php
@@ -63,15 +63,14 @@ class EventProvider implements Provider
 
                     return $dispatcher;
                 },
-                SymfonyEventDispatcherInterface::class => new ConfigBasedDefinitionReplacer(
-                    defaultClass: EventDispatcher::class,
-                    configKey: 'event.dispatcher',
-                ),
-                ListenerProvider::class => new ConfigBasedDefinitionReplacer(
-                    defaultClass: EventListenerProvider::class,
-                    configKey: 'event.provider',
-                ),
                 ListenerProviderInterface::class => get(ListenerProvider::class),
+                ...ConfigBasedDefinitionReplacer::createDependencyDefinitions(
+                    dependencies: [
+                        SymfonyEventDispatcherInterface::class => EventDispatcher::class,
+                        ListenerProvider::class => EventListenerProvider::class,
+                    ],
+                    configKeyPrefix: 'event',
+                )
             ],
         );
     }

--- a/src/Bootstrap/Provider/HttpProvider.php
+++ b/src/Bootstrap/Provider/HttpProvider.php
@@ -82,7 +82,6 @@ class HttpProvider implements Provider
                 SlimHttp::class => function (
                     Slim $slim,
                     SlimConfigurer $configurer,
-                    EventDispatcherInterface $dispatcher,
                     Hook $hook,
                 ): SlimHttp {
                     $adapter = new SlimHttp(

--- a/src/Bootstrap/Provider/HttpProvider.php
+++ b/src/Bootstrap/Provider/HttpProvider.php
@@ -4,7 +4,6 @@ namespace Takemo101\Chubby\Bootstrap\Provider;
 
 use Slim\App as Slim;
 use Nyholm\Psr7\Factory\Psr17Factory;
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;

--- a/src/Bootstrap/Provider/HttpProvider.php
+++ b/src/Bootstrap/Provider/HttpProvider.php
@@ -200,7 +200,7 @@ class HttpProvider implements Provider
                     return $middlewares;
                 },
                 ...ConfigBasedDefinitionReplacer::createDependencyDefinitions(
-                    defaultDependencies: [
+                    dependencies: [
                         SlimFactory::class => DefaultSlimFactory::class,
                         SlimConfigurer::class => DefaultSlimConfigurer::class,
                         ErrorHandlerInterface::class => ErrorHandler::class,

--- a/src/Bootstrap/Provider/HttpProvider.php
+++ b/src/Bootstrap/Provider/HttpProvider.php
@@ -67,14 +67,6 @@ class HttpProvider implements Provider
         $definitions->add(
             [
                 InvocationStrategyInterface::class => get(ControllerInvoker::class),
-                SlimFactory::class => new ConfigBasedDefinitionReplacer(
-                    defaultClass: DefaultSlimFactory::class,
-                    configKey: 'slim.factory',
-                ),
-                SlimConfigurer::class => new ConfigBasedDefinitionReplacer(
-                    defaultClass: DefaultSlimConfigurer::class,
-                    configKey: 'slim.configurer',
-                ),
                 Slim::class => function (
                     SlimFactory $factory,
                     Hook $hook,
@@ -139,10 +131,6 @@ class HttpProvider implements Provider
 
                     return $renders;
                 },
-                ErrorHandlerInterface::class => new ConfigBasedDefinitionReplacer(
-                    configKey: 'slim.error.handler',
-                    defaultClass: ErrorHandler::class,
-                ),
                 ErrorHandler::class => function (
                     Slim $slim,
                     LoggerInterface $logger,
@@ -211,7 +199,15 @@ class HttpProvider implements Provider
                     $hook->doTyped($middlewares, true);
 
                     return $middlewares;
-                }
+                },
+                ...ConfigBasedDefinitionReplacer::createDependencyDefinitions(
+                    defaultDependencies: [
+                        SlimFactory::class => DefaultSlimFactory::class,
+                        SlimConfigurer::class => DefaultSlimConfigurer::class,
+                        ErrorHandlerInterface::class => ErrorHandler::class,
+                    ],
+                    configKeyPrefix: 'slim',
+                )
             ],
         );
     }

--- a/src/Bootstrap/Support/ConfigBasedDefinitionReplacer.php
+++ b/src/Bootstrap/Support/ConfigBasedDefinitionReplacer.php
@@ -23,12 +23,12 @@ class ConfigBasedDefinitionReplacer implements DefinitionHelper
      *
      * @param class-string $defaultClass Default class when there is no class to support entry
      * @param string $configKey Configuration key to get the class name
-     * @param boolean $hook Whether to hook the replacement process
+     * @param boolean $shouldHook Whether to hook the replacement process
      */
     public function __construct(
         private readonly string $defaultClass,
         private readonly string $configKey,
-        private readonly bool $hook = false,
+        private readonly bool $shouldHook = false,
     ) {
         //
     }
@@ -62,7 +62,6 @@ class ConfigBasedDefinitionReplacer implements DefinitionHelper
      * Handler to generate an instance corresponding to the config key.
      *
      * @param ConfigRepository $config
-     * @param Hook $hook
      * @param ContainerInterface $container
      * @param RequestedEntry $entry
      * @return T
@@ -70,7 +69,6 @@ class ConfigBasedDefinitionReplacer implements DefinitionHelper
      */
     public function __invoke(
         ConfigRepository $config,
-        Hook $hook,
         ContainerInterface $container,
         RequestedEntry $entry,
     ): object {
@@ -94,7 +92,7 @@ class ConfigBasedDefinitionReplacer implements DefinitionHelper
             );
         }
 
-        if ($this->hook) {
+        if ($this->shouldHook) {
             /** @var Hook */
             $hook = $container->get(Hook::class);
 

--- a/src/Bootstrap/Support/ConfigBasedDefinitionReplacer.php
+++ b/src/Bootstrap/Support/ConfigBasedDefinitionReplacer.php
@@ -119,13 +119,13 @@ class ConfigBasedDefinitionReplacer implements DefinitionHelper
     /**
      * Generates an array of dependency definitions by specifying the default values for interfaces and their corresponding implementation classes.
      *
-     * @param array<class-string,class-string> $defaultDependencies Default class for each entry class
+     * @param array<class-string,class-string> $dependencies Default class for each entry class
      * @param string $configKeyPrefix Configuration key prefix
      * @param boolean $shouldHook Whether to hook the replacement process
      * @return array<class-string,ConfigBasedDefinitionReplacer> Dependency definitions
      */
     public static function createDependencyDefinitions(
-        array $defaultDependencies,
+        array $dependencies,
         string $configKeyPrefix,
         bool $shouldHook = true,
     ): array {
@@ -140,7 +140,7 @@ class ConfigBasedDefinitionReplacer implements DefinitionHelper
 
         $dependencyConfigKey = self::DependencyConfigKey;
 
-        foreach ($defaultDependencies as $entryClass => $defaultClass) {
+        foreach ($dependencies as $entryClass => $defaultClass) {
             $configKey = "{$configKeyPrefix}.{$dependencyConfigKey}.{$entryClass}";
 
             $definitions[$entryClass] = new self(

--- a/src/Bootstrap/Support/ConfigBasedDefinitionReplacer.php
+++ b/src/Bootstrap/Support/ConfigBasedDefinitionReplacer.php
@@ -31,9 +31,9 @@ class ConfigBasedDefinitionReplacer implements DefinitionHelper
      * @param boolean $shouldHook Whether to hook the replacement process
      */
     public function __construct(
-        private readonly string $defaultClass,
-        private readonly string $configKey,
-        private readonly bool $shouldHook = false,
+        public readonly string $defaultClass,
+        public readonly string $configKey,
+        public readonly bool $shouldHook = false,
     ) {
         assert(
             class_exists($defaultClass),

--- a/src/Bootstrap/Support/ConfigBasedDefinitionReplacer.php
+++ b/src/Bootstrap/Support/ConfigBasedDefinitionReplacer.php
@@ -59,7 +59,7 @@ class ConfigBasedDefinitionReplacer implements DefinitionHelper
     }
 
     /**
-     * コンフィグキーに対応するインスタンスを生成するハンドラ
+     * Handler to generate an instance corresponding to the config key.
      *
      * @param ConfigRepository $config
      * @param Hook $hook

--- a/src/Bootstrap/Support/ConfigBasedDefinitionReplacer.php
+++ b/src/Bootstrap/Support/ConfigBasedDefinitionReplacer.php
@@ -41,8 +41,8 @@ class ConfigBasedDefinitionReplacer implements DefinitionHelper
         );
 
         assert(
-            empty($configKey) !== false,
-            "Config key is empty",
+            empty($configKey) === false,
+            'Config key is empty'
         );
     }
 
@@ -131,7 +131,7 @@ class ConfigBasedDefinitionReplacer implements DefinitionHelper
     ): array {
 
         assert(
-            empty($configKeyPrefix) !== false,
+            empty($configKeyPrefix) === false,
             "Config key prefix is empty",
         );
 

--- a/src/Bootstrap/Support/ConfigBasedDefinitionReplacer.php
+++ b/src/Bootstrap/Support/ConfigBasedDefinitionReplacer.php
@@ -115,4 +115,41 @@ class ConfigBasedDefinitionReplacer implements DefinitionHelper
 
         return $instance;
     }
+
+    /**
+     * Generates an array of dependency definitions by specifying the default values for interfaces and their corresponding implementation classes.
+     *
+     * @param array<class-string,class-string> $defaultDependencies Default class for each entry class
+     * @param string $configKeyPrefix Configuration key prefix
+     * @param boolean $shouldHook Whether to hook the replacement process
+     * @return array<class-string,ConfigBasedDefinitionReplacer> Dependency definitions
+     */
+    public static function createDependencyDefinitions(
+        array $defaultDependencies,
+        string $configKeyPrefix,
+        bool $shouldHook = true,
+    ): array {
+
+        assert(
+            empty($configKeyPrefix) !== false,
+            "Config key prefix is empty",
+        );
+
+        /** @var array<class-string,ConfigBasedDefinitionReplacer> */
+        $definitions = [];
+
+        $dependencyConfigKey = self::DependencyConfigKey;
+
+        foreach ($defaultDependencies as $entryClass => $defaultClass) {
+            $configKey = "{$configKeyPrefix}.{$dependencyConfigKey}.{$entryClass}";
+
+            $definitions[$entryClass] = new self(
+                defaultClass: $defaultClass,
+                configKey: $configKey,
+                shouldHook: $shouldHook,
+            );
+        }
+
+        return $definitions;
+    }
 }

--- a/src/Bootstrap/Support/ConfigBasedDefinitionReplacer.php
+++ b/src/Bootstrap/Support/ConfigBasedDefinitionReplacer.php
@@ -19,6 +19,11 @@ use Takemo101\Chubby\Hook\Hook;
 class ConfigBasedDefinitionReplacer implements DefinitionHelper
 {
     /**
+     * Configuration key for dependencies.
+     */
+    public const DependencyConfigKey = 'dependencies';
+
+    /**
      * constructor
      *
      * @param class-string $defaultClass Default class when there is no class to support entry
@@ -30,7 +35,15 @@ class ConfigBasedDefinitionReplacer implements DefinitionHelper
         private readonly string $configKey,
         private readonly bool $shouldHook = false,
     ) {
-        //
+        assert(
+            class_exists($defaultClass),
+            "Default class not found: {$defaultClass}",
+        );
+
+        assert(
+            empty($configKey) !== false,
+            "Config key is empty",
+        );
     }
 
     /**

--- a/tests/Bootstrap/ConfigBasedDefinitionReplacerTest.php
+++ b/tests/Bootstrap/ConfigBasedDefinitionReplacerTest.php
@@ -9,19 +9,19 @@ use Takemo101\Chubby\Bootstrap\Support\ConfigBasedDefinitionReplacer;
 use Mockery as m;
 use Takemo101\Chubby\Bootstrap\Support\DependencySupportException;
 
-beforeEach(function () {
-    $this->config = m::mock(ConfigRepository::class);
-    $this->hook = m::mock(Hook::class);
-    $this->container = m::mock(ContainerInterface::class);
-    $this->entry = m::mock(RequestedEntry::class);
-});
-
 describe(
     'ConfigBasedDefinitionReplacer',
     function () {
 
+        beforeEach(function () {
+            $this->config = m::mock(ConfigRepository::class);
+            $this->container = m::mock(ContainerInterface::class);
+            $this->hook = m::mock(Hook::class);
+            $this->entry = m::mock(RequestedEntry::class);
+        });
+
         it('should throw an exception if entry class does not exist', function () {
-            $replacer = new ConfigBasedDefinitionReplacer('DefaultClass', 'configKey');
+            $replacer = new ConfigBasedDefinitionReplacer(stdClass::class, 'configKey');
             $this->entry->shouldReceive('getName')->andReturn('NonExistentClass');
 
             expect(function () use ($replacer) {
@@ -30,7 +30,7 @@ describe(
         });
 
         it('should return a FactoryDefinition', function () {
-            $replacer = new ConfigBasedDefinitionReplacer('DefaultClass', 'configKey');
+            $replacer = new ConfigBasedDefinitionReplacer(stdClass::class, 'configKey');
             $this->entry->shouldReceive('getName')->andReturn(stdClass::class);
 
             $definition = $replacer->getDefinition(stdClass::class);
@@ -43,24 +43,24 @@ describe(
 
             $expected = new stdClass();
 
-            $replacer = new ConfigBasedDefinitionReplacer('DefaultClass', 'configKey');
+            $replacer = new ConfigBasedDefinitionReplacer(stdClass::class, 'configKey');
             $this->entry->shouldReceive('getName')->andReturn(stdClass::class);
-            $this->config->shouldReceive('get')->with('configKey', 'DefaultClass')->andReturn(stdClass::class);
+            $this->config->shouldReceive('get')->with('configKey', stdClass::class)->andReturn(stdClass::class);
             $this->container->shouldReceive('get')->with(stdClass::class)->andReturn($expected);
 
-            $instance = $replacer($this->config, $this->hook, $this->container, $this->entry);
+            $instance = $replacer($this->config, $this->container, $this->entry);
 
             expect($instance)->toBe($expected);
         });
 
         it('should throw an exception if the instance does not implement the entry class', function () {
-            $replacer = new ConfigBasedDefinitionReplacer('DefaultClass', 'configKey');
+            $replacer = new ConfigBasedDefinitionReplacer(stdClass::class, 'configKey');
             $this->entry->shouldReceive('getName')->andReturn('ExistingClass');
-            $this->config->shouldReceive('get')->with('configKey', 'DefaultClass')->andReturn('ConfiguredClass');
+            $this->config->shouldReceive('get')->with('configKey', stdClass::class)->andReturn('ConfiguredClass');
             $this->container->shouldReceive('get')->with('ConfiguredClass')->andReturn('InvalidInstance');
 
             expect(function () use ($replacer) {
-                $replacer($this->config, $this->hook, $this->container, $this->entry);
+                $replacer($this->config, $this->container, $this->entry);
             })->toThrow(DependencySupportException::class);
         });
 
@@ -68,16 +68,44 @@ describe(
 
             $expected = new stdClass();
 
-            $replacer = new ConfigBasedDefinitionReplacer('DefaultClass', 'configKey', true);
+            $replacer = new ConfigBasedDefinitionReplacer(stdClass::class, 'configKey', true);
             $this->entry->shouldReceive('getName')->andReturn(stdClass::class);
-            $this->config->shouldReceive('get')->with('configKey', 'DefaultClass')->andReturn('ConfiguredClass');
+            $this->config->shouldReceive('get')->with('configKey', stdClass::class)->andReturn('ConfiguredClass');
             $this->container->shouldReceive('get')->with('ConfiguredClass')->andReturn($expected);
             $this->container->shouldReceive('get')->with(Hook::class)->andReturn($this->hook);
             $this->hook->shouldReceive('do')->with(stdClass::class, $expected)->andReturn($expected);
 
-            $instance = $replacer($this->config, $this->hook, $this->container, $this->entry);
+            $instance = $replacer($this->config, $this->container, $this->entry);
 
             expect($instance)->toBe($expected);
+        });
+
+        it('should generate dependency definitions', function () {
+            $dependencies = [
+                'EntryClass1' => stdClass::class,
+                'EntryClass2' => stdClass::class,
+                'EntryClass3' => stdClass::class,
+            ];
+            $configKeyPrefix = 'config.prefix';
+            $shouldHook = true;
+
+            $definitions = ConfigBasedDefinitionReplacer::createDependencyDefinitions(
+                $dependencies,
+                $configKeyPrefix,
+                $shouldHook
+            );
+
+            expect($definitions)->toBeArray();
+            expect(count($definitions))->toBe(count($dependencies));
+
+            foreach ($dependencies as $entryClass => $defaultClass) {
+                $configKey = "{$configKeyPrefix}.dependencies.{$entryClass}";
+
+                expect($definitions[$entryClass])->toBeInstanceOf(ConfigBasedDefinitionReplacer::class);
+                expect($definitions[$entryClass]->defaultClass)->toBe($defaultClass);
+                expect($definitions[$entryClass]->configKey)->toBe($configKey);
+                expect($definitions[$entryClass]->shouldHook)->toBe($shouldHook);
+            }
         });
     }
 )->group('ConfigBasedDefinitionReplacer');


### PR DESCRIPTION
## Overview
Config file to allow setting dependencies for major interfaces using ``ConfigBasedDefinitionReplacer``.
By setting up a DI on the implementation of the ``Provider`` class using the ``ConfigBasedDefinitionReplacer``'s ``createDependencyDefinitions`` method, you can set the dependencies of the major interfaces in the ``config file``. dependencies`` setting in the ``configBasedDefinitionReplacer`` to set the dependencies for the main interfaces.

## Changes
1. Added ``createDependencyDefinitions`` method to ``ConfigBasedDefinitionReplacer``.
2. Fixed ``Provider`` dependency settings.
3. Added ``dependencies`` setting to the config file in the ``config`` directory.
