### PR TITLE
Fixed to work even if the ``config/log.php`` file does not exist

### DIFF
--- a/src/Bootstrap/Provider/LogProvider.php
+++ b/src/Bootstrap/Provider/LogProvider.php
@@ -126,6 +126,7 @@ class LogProvider implements Provider
                     ignoreEmptyContextAndExtra: true,
                     includeStacktraces: true,
                 ),
+                // This factory class ensures that it is always used as a default when the config file does not exist
                 FileHandlerFactory::class => function (
                     ApplicationPath $path,
                     ConfigRepository $config,

--- a/src/Bootstrap/Provider/LogProvider.php
+++ b/src/Bootstrap/Provider/LogProvider.php
@@ -21,6 +21,7 @@ use Takemo101\Chubby\Log\LoggerHandlerFactoryCollection;
 use Takemo101\Chubby\Log\LoggerHandlerFactoryResolver;
 use Takemo101\Chubby\Log\LoggerProcessorCollection;
 use Takemo101\Chubby\Log\LoggerProcessorResolver;
+use Takemo101\Chubby\Support\ApplicationPath;
 
 use function DI\get;
 
@@ -125,6 +126,23 @@ class LogProvider implements Provider
                     ignoreEmptyContextAndExtra: true,
                     includeStacktraces: true,
                 ),
+                FileHandlerFactory::class => function (
+                    ApplicationPath $path,
+                    ConfigRepository $config,
+                ) {
+                    /** @var string */
+                    $path = $config->get('config.log.file.path', $path->getStoragePath('logs'));
+                    /** @var string */
+                    $filename = $config->get('config.log.file.filename', 'error.log');
+                    /** @var integer */
+                    $permission = $config->get('config.log.file.permission', 0777);
+
+                    return new FileHandlerFactory(
+                        path: $path,
+                        filename: $filename,
+                        permission: $permission,
+                    );
+                },
             ],
         );
     }


### PR DESCRIPTION
## Overview
Fixed a bug that prevented testing and operation from passing due to the inability to instantiate the ``FileHandlerFactory`` class if the ``config/log.php`` file did not exist.