### PR TITLE
Fixed a flag to determine built-in servers

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -22,5 +22,9 @@ return [
     'timezone' => 'Asia/Tokyo',
 
     // Built-in server flag
-    'built_in_server' => (bool) env(ServeCommand::BuiltInServerEnvironment, false),
+    'built_in_server' => (bool) env(
+        ServeCommand::BuiltInServerEnvironment,
+        // If the server is running in the command line, it is a built-in server
+        php_sapi_name() === 'cli-server'
+    ),
 ];


### PR DESCRIPTION
## Overview
The code changes in `app.php` update the `built_in_server` flag to check if the server is running in the command line using `php_sapi_name()`. This refactor improves the accuracy of the flag and ensures that it is set correctly when using the built-in server.
