### PR TITLE
Made it so that all listeners are executed even if an exception occurs during listener execution in `EventDispatcher`.

### DIFF
--- a/src/Event/EventDispatcher.php
+++ b/src/Event/EventDispatcher.php
@@ -4,6 +4,8 @@ namespace Takemo101\Chubby\Event;
 
 use Psr\EventDispatcher\StoppableEventInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as SymfonyEventDispatcherInterface;
+use Takemo101\Chubby\Exception\Exceptions;
+use Throwable;
 
 class EventDispatcher implements SymfonyEventDispatcherInterface
 {
@@ -20,6 +22,8 @@ class EventDispatcher implements SymfonyEventDispatcherInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @throws Exceptions
      */
     public function dispatch(object $event, ?string $eventName = null): object
     {
@@ -27,17 +31,45 @@ class EventDispatcher implements SymfonyEventDispatcherInterface
             ? $this->provider->getListeners($eventName)
             : $this->provider->getListenersForEvent($event);
 
-        foreach ($listeners as $listener) {
-            call_user_func($listener, $event);
-
-            if (
-                $event instanceof StoppableEventInterface
-                && $event->isPropagationStopped()
-            ) {
-                break;
-            }
+        // If an exception occurs during the listener call, throw the exception.
+        if ($exceptions = $this->handleListeners($listeners, $event)) {
+            throw $exceptions;
         }
 
         return $event;
+    }
+
+    /**
+     * Executes all listener functions in the listener array and returns an exception if any occur.
+     * Returns null if no exceptions occur.
+     *
+     * If an exception occurs in a specific listener, it interrupts the execution of that listener and proceeds to the next one.
+     *
+     * @param iterable<callable> $listeners
+     * @param object $event
+     * @return Exceptions|null
+     */
+    private function handleListeners(iterable $listeners, object $event): ?Exceptions
+    {
+        $throwables = [];
+
+        foreach ($listeners as $listener) {
+            try {
+                call_user_func($listener, $event);
+
+                if (
+                    $event instanceof StoppableEventInterface
+                    && $event->isPropagationStopped()
+                ) {
+                    break;
+                }
+            } catch (Throwable $e) {
+                $throwables[] = $e;
+            }
+        }
+
+        return empty($throwables) === false
+            ? new Exceptions(...$throwables)
+            : null;
     }
 }

--- a/src/Event/EventDispatcher.php
+++ b/src/Event/EventDispatcher.php
@@ -4,7 +4,7 @@ namespace Takemo101\Chubby\Event;
 
 use Psr\EventDispatcher\StoppableEventInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as SymfonyEventDispatcherInterface;
-use Takemo101\Chubby\Exception\Exceptions;
+use Takemo101\Chubby\Event\Exception\EventListenerHandlingExceptions;
 use Throwable;
 
 class EventDispatcher implements SymfonyEventDispatcherInterface
@@ -23,7 +23,7 @@ class EventDispatcher implements SymfonyEventDispatcherInterface
     /**
      * {@inheritDoc}
      *
-     * @throws Exceptions
+     * @throws EventListenerHandlingExceptions
      */
     public function dispatch(object $event, ?string $eventName = null): object
     {
@@ -47,9 +47,9 @@ class EventDispatcher implements SymfonyEventDispatcherInterface
      *
      * @param iterable<callable> $listeners
      * @param object $event
-     * @return Exceptions|null
+     * @return EventListenerHandlingExceptions|null
      */
-    private function handleListeners(iterable $listeners, object $event): ?Exceptions
+    private function handleListeners(iterable $listeners, object $event): ?EventListenerHandlingExceptions
     {
         $throwables = [];
 
@@ -68,8 +68,6 @@ class EventDispatcher implements SymfonyEventDispatcherInterface
             }
         }
 
-        return empty($throwables) === false
-            ? new Exceptions(...$throwables)
-            : null;
+        return EventListenerHandlingExceptions::createIfNotEmpty(...$throwables);
     }
 }

--- a/src/Event/Exception/EventListenerHandlingExceptions.php
+++ b/src/Event/Exception/EventListenerHandlingExceptions.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Takemo101\Chubby\Event\Exception;
+
+use Takemo101\Chubby\Exception\Exceptions;
+use Throwable;
+
+/**
+ * Exception for handling multiple exceptions that occurred in event listeners.
+ */
+class EventListenerHandlingExceptions extends Exceptions
+{
+    public const Message = 'Multiple exceptions occurred in event listeners';
+
+    /**
+     * Create a new instance if the array is not empty.
+     *
+     * @param Throwable ...$throwables The exceptions that occurred.
+     * @return static|null
+     */
+    public static function createIfNotEmpty(Throwable ...$throwables): ?self
+    {
+        if (empty($throwables)) {
+            return null;
+        }
+
+        return new static(...$throwables);
+    }
+}

--- a/src/Exception/Exceptions.php
+++ b/src/Exception/Exceptions.php
@@ -14,6 +14,8 @@ use Throwable;
  */
 class Exceptions extends Exception implements Throwables
 {
+    public const Message = 'Multiple exceptions occurred';
+
     public const Code = 0;
 
     /**
@@ -38,8 +40,10 @@ class Exceptions extends Exception implements Throwables
 
         $this->throwables = $throwables;
 
+        $message = static::Message;
+
         parent::__construct(
-            message: "Multiple exceptions occurred: {$errorCount} errors.",
+            message: "{$message}: {$errorCount} errors.",
             code: static::Code,
         );
     }

--- a/tests/Event/EventDispatcherTest.php
+++ b/tests/Event/EventDispatcherTest.php
@@ -3,8 +3,8 @@
 use Takemo101\Chubby\Event\EventDispatcher;
 use Takemo101\Chubby\Event\StoppableEvent;
 use Takemo101\Chubby\Event\ListenerProvider;
-use Takemo101\Chubby\Exception\Exceptions;
 use Mockery as m;
+use Takemo101\Chubby\Event\Exception\EventListenerHandlingExceptions;
 
 describe(
     'EventDispatcher',
@@ -132,7 +132,7 @@ describe(
                 function () use ($event) {
                     $this->dispatcher->dispatch($event);
                 }
-            )->toThrow(Exceptions::class, 'Multiple exceptions occurred: 1 errors.');
+            )->toThrow(EventListenerHandlingExceptions::class);
         });
     }
 )->group('EventDispatcher', 'event');

--- a/tests/Event/EventDispatcherTest.php
+++ b/tests/Event/EventDispatcherTest.php
@@ -2,30 +2,28 @@
 
 use Takemo101\Chubby\Event\EventDispatcher;
 use Takemo101\Chubby\Event\StoppableEvent;
-use Mockery as m;
 use Takemo101\Chubby\Event\ListenerProvider;
+use Takemo101\Chubby\Exception\Exceptions;
+use Mockery as m;
 
 describe(
     'EventDispatcher',
     function () {
-
         beforeEach(function () {
             $this->provider = m::mock(ListenerProvider::class);
             $this->dispatcher = new EventDispatcher($this->provider);
         });
 
-        it('should dispatch event to listeners', function () {
+        it('should dispatch event to listeners and return the event object', function () {
             $event = new stdClass();
 
-            $listener1 = new class
-            {
+            $listener1 = new class {
                 public function __invoke(stdClass $event)
                 {
                     //
                 }
             };
-            $listener2 = new class
-            {
+            $listener2 = new class {
                 public function __invoke(stdClass $event)
                 {
                     //
@@ -42,17 +40,15 @@ describe(
             expect($actual)->toBe($event);
         });
 
-        it('should dispatch event to listeners with event name', function () {
+        it('should dispatch event to listeners with event name and return the event object', function () {
             $event = new stdClass();
-            $listener1 = new class
-            {
+            $listener1 = new class {
                 public function __invoke(stdClass $event)
                 {
                     //
                 }
             };
-            $listener2 = new class
-            {
+            $listener2 = new class {
                 public function __invoke(stdClass $event)
                 {
                     //
@@ -67,20 +63,18 @@ describe(
             expect($actual)->toBe($event);
         });
 
-        it('should stop propagation if event is stoppable', function () {
-            $event = new class() extends StoppableEvent
-            {
+        it('should stop propagation if event is stoppable and return the event object', function () {
+            $event = new class() extends StoppableEvent {
                 //
             };
 
-            $listener1 = new class
-            {
+            $listener1 = new class {
                 public function __invoke(StoppableEvent $event)
                 {
                     $event->stopPropagation();
                 }
             };
-            $listener2 =  m::mock(EventDispatcherTestListener::class);
+            $listener2 = m::mock(EventDispatcherTestListener::class);
 
             $this->provider->shouldReceive('getListenersForEvent')
                 ->once()
@@ -94,13 +88,11 @@ describe(
             expect($actual)->toBe($event);
         });
 
-        it('should stop propagation if event is stoppable with event name', function () {
-            $event = new class() extends StoppableEvent
-            {
+        it('should stop propagation if event is stoppable with event name and return the event object', function () {
+            $event = new class() extends StoppableEvent {
                 //
             };
-            $listener1 = new class
-            {
+            $listener1 = new class {
                 public function __invoke(StoppableEvent $event)
                 {
                     $event->stopPropagation();
@@ -115,6 +107,32 @@ describe(
             $listener2->shouldNotReceive('__invoke');
             $actual = $this->dispatcher->dispatch($event, 'event.name');
             expect($actual)->toBe($event);
+        });
+
+        it('should throw an exception if an exception occurs during listener call', function () {
+            $event = new stdClass();
+            $listener1 = new class {
+                public function __invoke(stdClass $event)
+                {
+                    throw new Exception('Listener 1 exception');
+                }
+            };
+            $listener2 = new class {
+                public function __invoke(stdClass $event)
+                {
+                    //
+                }
+            };
+            $this->provider->shouldReceive('getListenersForEvent')
+                ->once()
+                ->with($event)
+                ->andReturn([$listener1, $listener2]);
+
+            expect(
+                function () use ($event) {
+                    $this->dispatcher->dispatch($event);
+                }
+            )->toThrow(Exceptions::class, 'Multiple exceptions occurred: 1 errors.');
         });
     }
 )->group('EventDispatcher', 'event');


### PR DESCRIPTION
## Overview
Made it so that all listeners are executed even if an exception occurs during listener execution in `EventDispatcher`.
Exceptions that occur in listeners are thrown together as `Exceptions`.

